### PR TITLE
Unite TestSeries classes

### DIFF
--- a/src/fido2_conformance_main.cc
+++ b/src/fido2_conformance_main.cc
@@ -54,55 +54,52 @@ int main(int argc, char** argv) {
       << "CTAPHID initialization failed";
   device->Wink();
 
-  fido2_tests::InputParameterTestSeries input_parameter_test_series =
-      fido2_tests::InputParameterTestSeries(device.get(), &tracker);
-  fido2_tests::SpecificationProcedure specification_procedure_test_series =
-      fido2_tests::SpecificationProcedure(device.get(), &tracker);
+  fido2_tests::TestSeries test_series =
+      fido2_tests::TestSeries(device.get(), &tracker);
 
-  specification_procedure_test_series.Reset();
+  test_series.Reset();
   // You need to execute GetInfo first to initialize the tracker.
-  specification_procedure_test_series.GetInfoTest();
+  test_series.GetInfoTest();
 
-  input_parameter_test_series.MakeCredentialBadParameterTypesTest();
-  input_parameter_test_series.MakeCredentialMissingParameterTest();
-  input_parameter_test_series.MakeCredentialRelyingPartyEntityTest();
-  input_parameter_test_series.MakeCredentialUserEntityTest();
-  input_parameter_test_series.MakeCredentialExcludeListTest();
-  input_parameter_test_series.MakeCredentialExtensionsTest();
-  input_parameter_test_series.GetAssertionBadParameterTypesTest();
-  input_parameter_test_series.GetAssertionMissingParameterTest();
-  input_parameter_test_series.GetAssertionAllowListTest();
-  input_parameter_test_series.GetAssertionExtensionsTest();
-  input_parameter_test_series.ClientPinGetPinRetriesTest();
-  input_parameter_test_series.ClientPinGetKeyAgreementTest();
-  input_parameter_test_series.ClientPinSetPinTest();
-  input_parameter_test_series.ClientPinChangePinTest();
-  input_parameter_test_series.ClientPinGetPinUvAuthTokenUsingPinTest();
-  input_parameter_test_series.ClientPinGetPinUvAuthTokenUsingUvTest();
-  input_parameter_test_series.ClientPinGetUVRetriesTest();
+  test_series.MakeCredentialBadParameterTypesTest();
+  test_series.MakeCredentialMissingParameterTest();
+  test_series.MakeCredentialRelyingPartyEntityTest();
+  test_series.MakeCredentialUserEntityTest();
+  test_series.MakeCredentialExcludeListCredentialDescriptorTest();
+  test_series.MakeCredentialExtensionsTest();
+  test_series.GetAssertionBadParameterTypesTest();
+  test_series.GetAssertionMissingParameterTest();
+  test_series.GetAssertionAllowListCredentialDescriptorTest();
+  test_series.GetAssertionExtensionsTest();
+  test_series.ClientPinGetPinRetriesTest();
+  test_series.ClientPinGetKeyAgreementTest();
+  test_series.ClientPinSetPinTest();
+  test_series.ClientPinChangePinTest();
+  test_series.ClientPinGetPinUvAuthTokenUsingPinTest();
+  test_series.ClientPinGetPinUvAuthTokenUsingUvTest();
+  test_series.ClientPinGetUVRetriesTest();
 
-  specification_procedure_test_series.ResetDeletionTest();
-  specification_procedure_test_series.ResetPhysicalPresenceTest();
-  specification_procedure_test_series.PersistenceTest();
+  test_series.ResetDeletionTest();
+  test_series.ResetPhysicalPresenceTest();
+  test_series.PersistenceTest();
 
-  specification_procedure_test_series.MakeCredentialExcludeListTest();
-  specification_procedure_test_series.MakeCredentialCoseAlgorithmTest();
-  specification_procedure_test_series.MakeCredentialOptionsTest();
-  specification_procedure_test_series.MakeCredentialPinAuthTest();
-  specification_procedure_test_series.MakeCredentialMultipleKeysTest(
-      FLAGS_num_credentials);
-  specification_procedure_test_series.MakeCredentialPhysicalPresenceTest();
-  specification_procedure_test_series.MakeCredentialDisplayNameEncodingTest();
+  test_series.MakeCredentialExcludeListTest();
+  test_series.MakeCredentialCoseAlgorithmTest();
+  test_series.MakeCredentialOptionsTest();
+  test_series.MakeCredentialPinAuthTest();
+  test_series.MakeCredentialMultipleKeysTest(FLAGS_num_credentials);
+  test_series.MakeCredentialPhysicalPresenceTest();
+  test_series.MakeCredentialDisplayNameEncodingTest();
 
-  specification_procedure_test_series.GetAssertionOptionsTest();
-  specification_procedure_test_series.GetAssertionResidentialKeyTest();
-  specification_procedure_test_series.GetAssertionPinAuthTest();
-  specification_procedure_test_series.GetAssertionPhysicalPresenceTest();
+  test_series.GetAssertionOptionsTest();
+  test_series.GetAssertionResidentialKeyTest();
+  test_series.GetAssertionPinAuthTest();
+  test_series.GetAssertionPhysicalPresenceTest();
 
-  specification_procedure_test_series.ClientPinRequirementsTest();
-  specification_procedure_test_series.ClientPinRequirements2Point1Test();
-  specification_procedure_test_series.ClientPinRetriesTest();
-  specification_procedure_test_series.MakeCredentialHmacSecretTest();
+  test_series.ClientPinRequirementsTest();
+  test_series.ClientPinRequirements2Point1Test();
+  test_series.ClientPinRetriesTest();
+  test_series.MakeCredentialHmacSecretTest();
 
   std::cout << "\nRESULTS" << std::endl;
   tracker.ReportFindings();

--- a/src/test_series.cc
+++ b/src/test_series.cc
@@ -134,11 +134,11 @@ void PrintNoTouchPrompt() {
 }
 }  // namespace
 
-InputParameterTestSeries::InputParameterTestSeries(
-    DeviceInterface* device, DeviceTracker* device_tracker)
+TestSeries::TestSeries(DeviceInterface* device, DeviceTracker* device_tracker)
     : device_(device),
       device_tracker_(device_tracker),
-      cose_key_example_(crypto_utility::GenerateExampleEcdhCoseKey()) {
+      cose_key_example_(crypto_utility::GenerateExampleEcdhCoseKey()),
+      bad_pin_({0x66, 0x61, 0x6B, 0x65}) {
   cbor::Value::ArrayValue array_example;
   array_example.push_back(cbor::Value(42));
   cbor::Value::MapValue map_example;
@@ -161,7 +161,7 @@ InputParameterTestSeries::InputParameterTestSeries(
   map_key_examples_[cbor::Value::Type::STRING] = cbor::Value("42");
 }
 
-void InputParameterTestSeries::MakeCredentialBadParameterTypesTest() {
+void TestSeries::MakeCredentialBadParameterTypesTest() {
   std::string rp_id = "make_bad_types.example.com";
   MakeCredentialCborBuilder full_builder;
 
@@ -202,7 +202,7 @@ void InputParameterTestSeries::MakeCredentialBadParameterTypesTest() {
   TestBadParameterTypes(Command::kAuthenticatorMakeCredential, &full_builder);
 }
 
-void InputParameterTestSeries::MakeCredentialMissingParameterTest() {
+void TestSeries::MakeCredentialMissingParameterTest() {
   std::string rp_id = "make_missing.example.com";
   MakeCredentialCborBuilder missing_required_builder;
   missing_required_builder.AddDefaultsForRequiredFields(rp_id);
@@ -215,7 +215,7 @@ void InputParameterTestSeries::MakeCredentialMissingParameterTest() {
   // the list is missing entirely.
 }
 
-void InputParameterTestSeries::MakeCredentialRelyingPartyEntityTest() {
+void TestSeries::MakeCredentialRelyingPartyEntityTest() {
   constexpr MakeCredentialParameters kKey = MakeCredentialParameters::kRp;
   std::string rp_id = absl::StrCat("make_parameter_rp.example.com");
   absl::variant<cbor::Value, Status> response;
@@ -242,7 +242,7 @@ void InputParameterTestSeries::MakeCredentialRelyingPartyEntityTest() {
       response, "recognize optional icon in relying party entity");
 }
 
-void InputParameterTestSeries::MakeCredentialUserEntityTest() {
+void TestSeries::MakeCredentialUserEntityTest() {
   constexpr MakeCredentialParameters kKey = MakeCredentialParameters::kUser;
   std::string rp_id = absl::StrCat("make_parameter_user.example.com");
   absl::variant<cbor::Value, Status> response;
@@ -280,7 +280,7 @@ void InputParameterTestSeries::MakeCredentialUserEntityTest() {
       response, "recognize optional displayName in user entity");
 }
 
-void InputParameterTestSeries::MakeCredentialExcludeListTest() {
+void TestSeries::MakeCredentialExcludeListCredentialDescriptorTest() {
   constexpr MakeCredentialParameters kKey =
       MakeCredentialParameters::kExcludeList;
   std::string rp_id = absl::StrCat("make_parameter_exclude_list.example.com");
@@ -306,7 +306,7 @@ void InputParameterTestSeries::MakeCredentialExcludeListTest() {
                                   "accept a valid credential descriptor");
 }
 
-void InputParameterTestSeries::MakeCredentialExtensionsTest() {
+void TestSeries::MakeCredentialExtensionsTest() {
   constexpr MakeCredentialParameters kKey =
       MakeCredentialParameters::kExtensions;
   std::string rp_id = absl::StrCat("make_parameter_extensions.example.com");
@@ -322,7 +322,7 @@ void InputParameterTestSeries::MakeCredentialExtensionsTest() {
   device_tracker_->CheckAndReport(response, "accept valid extension");
 }
 
-void InputParameterTestSeries::GetAssertionBadParameterTypesTest() {
+void TestSeries::GetAssertionBadParameterTypesTest() {
   std::string rp_id = "get_bad_types.example.com";
   cbor::Value credential_response = MakeTestCredential(rp_id, false);
   cbor::Value::BinaryValue credential_id =
@@ -346,7 +346,7 @@ void InputParameterTestSeries::GetAssertionBadParameterTypesTest() {
   TestBadParameterTypes(Command::kAuthenticatorGetAssertion, &full_builder);
 }
 
-void InputParameterTestSeries::GetAssertionMissingParameterTest() {
+void TestSeries::GetAssertionMissingParameterTest() {
   std::string rp_id = "get_missing.example.com";
   MakeTestCredential(rp_id, true);
 
@@ -356,7 +356,7 @@ void InputParameterTestSeries::GetAssertionMissingParameterTest() {
                         &missing_required_builder);
 }
 
-void InputParameterTestSeries::GetAssertionAllowListTest() {
+void TestSeries::GetAssertionAllowListCredentialDescriptorTest() {
   constexpr GetAssertionParameters kKey = GetAssertionParameters::kAllowList;
   std::string rp_id = absl::StrCat("get_parameter_allow_list.example.com");
   absl::variant<cbor::Value, Status> response;
@@ -388,7 +388,7 @@ void InputParameterTestSeries::GetAssertionAllowListTest() {
                                   "accept a valid credential descriptor");
 }
 
-void InputParameterTestSeries::GetAssertionExtensionsTest() {
+void TestSeries::GetAssertionExtensionsTest() {
   constexpr GetAssertionParameters kKey = GetAssertionParameters::kExtensions;
   std::string rp_id = absl::StrCat("get_parameter", kKey, ".example.com");
   absl::variant<cbor::Value, Status> response;
@@ -407,14 +407,14 @@ void InputParameterTestSeries::GetAssertionExtensionsTest() {
   device_tracker_->CheckAndReport(response, "accept a valid extension");
 }
 
-void InputParameterTestSeries::ClientPinGetPinRetriesTest() {
+void TestSeries::ClientPinGetPinRetriesTest() {
   AuthenticatorClientPinCborBuilder pin1_builder;
   pin1_builder.AddDefaultsForGetPinRetries();
   TestBadParameterTypes(Command::kAuthenticatorClientPIN, &pin1_builder);
   TestMissingParameters(Command::kAuthenticatorClientPIN, &pin1_builder);
 }
 
-void InputParameterTestSeries::ClientPinGetKeyAgreementTest() {
+void TestSeries::ClientPinGetKeyAgreementTest() {
   // crypto_utility enforces that the COSE key map only has the correct entries.
   AuthenticatorClientPinCborBuilder pin2_builder;
   pin2_builder.AddDefaultsForGetKeyAgreement();
@@ -422,7 +422,7 @@ void InputParameterTestSeries::ClientPinGetKeyAgreementTest() {
   TestMissingParameters(Command::kAuthenticatorClientPIN, &pin2_builder);
 }
 
-void InputParameterTestSeries::ClientPinSetPinTest() {
+void TestSeries::ClientPinSetPinTest() {
   AuthenticatorClientPinCborBuilder pin3_builder;
   pin3_builder.AddDefaultsForSetPin(cose_key_example_,
                                     cbor::Value::BinaryValue(),
@@ -431,7 +431,7 @@ void InputParameterTestSeries::ClientPinSetPinTest() {
   TestMissingParameters(Command::kAuthenticatorClientPIN, &pin3_builder);
 }
 
-void InputParameterTestSeries::ClientPinChangePinTest() {
+void TestSeries::ClientPinChangePinTest() {
   AuthenticatorClientPinCborBuilder pin4_builder;
   pin4_builder.AddDefaultsForChangePin(
       cose_key_example_, cbor::Value::BinaryValue(), cbor::Value::BinaryValue(),
@@ -440,7 +440,7 @@ void InputParameterTestSeries::ClientPinChangePinTest() {
   TestMissingParameters(Command::kAuthenticatorClientPIN, &pin4_builder);
 }
 
-void InputParameterTestSeries::ClientPinGetPinUvAuthTokenUsingPinTest() {
+void TestSeries::ClientPinGetPinUvAuthTokenUsingPinTest() {
   AuthenticatorClientPinCborBuilder pin5_builder;
   pin5_builder.AddDefaultsForGetPinUvAuthTokenUsingPin(
       cose_key_example_, cbor::Value::BinaryValue());
@@ -448,7 +448,7 @@ void InputParameterTestSeries::ClientPinGetPinUvAuthTokenUsingPinTest() {
   TestMissingParameters(Command::kAuthenticatorClientPIN, &pin5_builder);
 }
 
-void InputParameterTestSeries::ClientPinGetPinUvAuthTokenUsingUvTest() {
+void TestSeries::ClientPinGetPinUvAuthTokenUsingUvTest() {
   if (!IsFido2Point1Complicant()) {
     return;
   }
@@ -458,7 +458,7 @@ void InputParameterTestSeries::ClientPinGetPinUvAuthTokenUsingUvTest() {
   TestMissingParameters(Command::kAuthenticatorClientPIN, &pin6_builder);
 }
 
-void InputParameterTestSeries::ClientPinGetUVRetriesTest() {
+void TestSeries::ClientPinGetUVRetriesTest() {
   if (!IsFido2Point1Complicant()) {
     return;
   }
@@ -468,201 +468,7 @@ void InputParameterTestSeries::ClientPinGetUVRetriesTest() {
   TestMissingParameters(Command::kAuthenticatorClientPIN, &pin7_builder);
 }
 
-bool InputParameterTestSeries::IsFido2Point1Complicant() {
-  return device_tracker_->HasVersion("FIDO_2_1_PRE");
-}
-
-cbor::Value InputParameterTestSeries::MakeTestCredential(
-    const std::string& rp_id, bool use_residential_key) {
-  MakeCredentialCborBuilder test_builder;
-  test_builder.AddDefaultsForRequiredFields(rp_id);
-  test_builder.SetResidentialKeyOptions(use_residential_key);
-
-  absl::variant<cbor::Value, Status> response =
-      fido2_commands::MakeCredentialPositiveTest(device_, device_tracker_,
-                                                 test_builder.GetCbor());
-  AssertResponse(response, "make credential for further tests");
-  return std::move(absl::get<cbor::Value>(response));
-}
-
-void InputParameterTestSeries::TestBadParameterTypes(Command command,
-                                                     CborBuilder* builder) {
-  for (const auto& item : type_examples_) {
-    if (item.first != cbor::Value::Type::MAP) {
-      Status returned_status = fido2_commands::GenericNegativeTest(
-          device_, item.second, command, false);
-      device_tracker_->CheckAndReport(
-          Status::kErrCborUnexpectedType, returned_status,
-          absl::StrCat("bad type ", CborTypeToString(item.first), " in ",
-                       CommandToString(command), " for the request"));
-    }
-  }
-
-  const cbor::Value map_cbor = builder->GetCbor();
-  for (const auto& map_entry : map_cbor.GetMap()) {
-    auto map_key = map_entry.first.Clone();
-    CHECK(map_key.is_unsigned()) << "map key not integer - TEST SUITE BUG";
-    auto map_value = map_entry.second.Clone();
-
-    // Replace the map value with another of wrong type. Maps and arrays get
-    // additional tests.
-    for (const auto& item : type_examples_) {
-      if (item.second.is_integer() && map_value.is_integer()) {
-        continue;
-      }
-      if (!map_value.is_type(item.first)) {
-        builder->SetArbitraryMapEntry(map_key.GetInteger(),
-                                      item.second.Clone());
-        Status returned_status = fido2_commands::GenericNegativeTest(
-            device_, builder->GetCbor(), command, false);
-        device_tracker_->CheckAndReport(
-            Status::kErrCborUnexpectedType, returned_status,
-            absl::StrCat("bad type ", CborTypeToString(item.first), " in ",
-                         CommandToString(command), " for key ",
-                         map_key.GetInteger()));
-      }
-    }
-
-    if (map_value.is_map()) {
-      TestBadParametersInInnerMap(command, builder, map_key.GetInteger(),
-                                  map_value.GetMap(), false);
-    }
-
-    // Checking types for the first element (assuming all have the same type).
-    if (map_value.is_array()) {
-      const cbor::Value& element = map_value.GetArray()[0];
-      TestBadParametersInInnerArray(command, builder, map_key.GetInteger(),
-                                    element);
-
-      if (element.is_map()) {
-        TestBadParametersInInnerMap(command, builder, map_key.GetInteger(),
-                                    element.GetMap(), true);
-      }
-    }
-
-    // Undo calls to builder->SetArbitraryMapEntry (including sub-functions).
-    builder->SetArbitraryMapEntry(std::move(map_key), std::move(map_value));
-  }
-}
-
-void InputParameterTestSeries::TestMissingParameters(Command command,
-                                                     CborBuilder* builder) {
-  const cbor::Value map_cbor = builder->GetCbor();
-  for (const auto& parameter : map_cbor.GetMap()) {
-    auto map_key = parameter.first.Clone();
-    auto map_value = parameter.second.Clone();
-    builder->RemoveArbitraryMapEntry(map_key.Clone());
-    Status returned_status = fido2_commands::GenericNegativeTest(
-        device_, builder->GetCbor(), command, false);
-    device_tracker_->CheckAndReport(
-        Status::kErrMissingParameter, returned_status,
-        absl::StrCat("missing ", CborToString("key", map_key), " for command ",
-                     CommandToString(command)));
-    builder->SetArbitraryMapEntry(std::move(map_key), std::move(map_value));
-  }
-}
-
-void InputParameterTestSeries::TestBadParametersInInnerMap(
-    Command command, CborBuilder* builder, int outer_map_key,
-    const cbor::Value::MapValue& inner_map, bool has_wrapping_array) {
-  cbor::Value::MapValue test_map;
-  for (const auto& inner_entry : inner_map) {
-    test_map[inner_entry.first.Clone()] = inner_entry.second.Clone();
-  }
-  for (const auto& inner_entry : inner_map) {
-    auto inner_key = inner_entry.first.Clone();
-    auto inner_value = inner_entry.second.Clone();
-
-    for (const auto& item : type_examples_) {
-      if (item.second.is_integer() && inner_value.is_integer()) {
-        continue;
-      }
-      if (!inner_value.is_type(item.first)) {
-        test_map[inner_key.Clone()] = item.second.Clone();
-        if (has_wrapping_array) {
-          cbor::Value::ArrayValue test_array;
-          test_array.push_back(cbor::Value(test_map));
-          builder->SetArbitraryMapEntry(outer_map_key, cbor::Value(test_array));
-        } else {
-          builder->SetArbitraryMapEntry(outer_map_key, cbor::Value(test_map));
-        }
-        Status returned_status = fido2_commands::GenericNegativeTest(
-            device_, builder->GetCbor(), command, false);
-        device_tracker_->CheckAndReport(
-            Status::kErrCborUnexpectedType, returned_status,
-            absl::StrCat("bad type ", CborTypeToString(item.first), " in ",
-                         CommandToString(command), " in ",
-                         CborToString("inner key", inner_key),
-                         " in array at map key ", outer_map_key));
-      }
-    }
-    test_map[std::move(inner_key)] = std::move(inner_value);
-  }
-}
-
-void InputParameterTestSeries::TestBadParametersInInnerArray(
-    Command command, CborBuilder* builder, int outer_map_key,
-    const cbor::Value& array_element) {
-  for (const auto& item : type_examples_) {
-    if (item.second.is_integer() && array_element.is_integer()) {
-      continue;
-    }
-    if (!array_element.is_type(item.first)) {
-      cbor::Value::ArrayValue test_array;
-      test_array.push_back(array_element.Clone());
-      test_array.push_back(item.second.Clone());
-      builder->SetArbitraryMapEntry(outer_map_key, cbor::Value(test_array));
-      Status returned_status = fido2_commands::GenericNegativeTest(
-          device_, builder->GetCbor(), command, false);
-      device_tracker_->CheckAndReport(
-          Status::kErrCborUnexpectedType, returned_status,
-          absl::StrCat("bad type ", CborTypeToString(item.first), " in ",
-                       CommandToString(command),
-                       " in array element at map key ", outer_map_key));
-    }
-  }
-}
-
-void InputParameterTestSeries::TestCredentialDescriptorsArrayForCborDepth(
-    Command command, CborBuilder* builder, int map_key,
-    const std::string& rp_id) {
-  Status returned_status;
-  absl::variant<cbor::Value, Status> response;
-
-  cbor::Value::BinaryValue cred_descriptor_id(32, 0xce);
-  for (const auto& item : type_examples_) {
-    if (item.first == cbor::Value::Type::ARRAY ||
-        item.first == cbor::Value::Type::MAP) {
-      cbor::Value::ArrayValue credential_descriptor_list;
-      cbor::Value::MapValue test_cred_descriptor;
-      test_cred_descriptor[cbor::Value("type")] = cbor::Value("public-key");
-      test_cred_descriptor[cbor::Value("id")] = cbor::Value(cred_descriptor_id);
-      cbor::Value::ArrayValue transports;
-      transports.push_back(cbor::Value("usb"));
-      transports.push_back(item.second.Clone());
-      test_cred_descriptor[cbor::Value("transports")] = cbor::Value(transports);
-      credential_descriptor_list.push_back(cbor::Value(test_cred_descriptor));
-      builder->SetArbitraryMapEntry(map_key,
-                                    cbor::Value(credential_descriptor_list));
-      returned_status = fido2_commands::GenericNegativeTest(
-          device_, builder->GetCbor(), command, false);
-      device_tracker_->CheckAndReport(
-          Status::kErrInvalidCbor, returned_status,
-          absl::StrCat("maximum CBOR nesting depth exceeded with ",
-                       CborTypeToString(item.first),
-                       " in credential descriptor transport list item in ",
-                       CommandToString(command), " for key ", map_key));
-    }
-  }
-}
-
-SpecificationProcedure::SpecificationProcedure(DeviceInterface* device,
-                                               DeviceTracker* device_tracker)
-    : device_(device),
-      device_tracker_(device_tracker),
-      bad_pin_({0x66, 0x61, 0x6B, 0x65}) {}
-
-void SpecificationProcedure::MakeCredentialExcludeListTest() {
+void TestSeries::MakeCredentialExcludeListTest() {
   std::string rp_id = "exclude.example.com";
   Status returned_status;
   absl::variant<cbor::Value, Status> response;
@@ -698,7 +504,7 @@ void SpecificationProcedure::MakeCredentialExcludeListTest() {
       response, "make a credential for an unrelated relying party");
 }
 
-void SpecificationProcedure::MakeCredentialCoseAlgorithmTest() {
+void TestSeries::MakeCredentialCoseAlgorithmTest() {
   std::string rp_id = "algorithm.example.com";
   Status returned_status;
   absl::variant<cbor::Value, Status> response;
@@ -759,7 +565,7 @@ void SpecificationProcedure::MakeCredentialCoseAlgorithmTest() {
       response, "accept credential parameter list with 1 good and 1 bad item");
 }
 
-void SpecificationProcedure::MakeCredentialOptionsTest() {
+void TestSeries::MakeCredentialOptionsTest() {
   std::string rp_id = "options.example.com";
   Status returned_status;
   absl::variant<cbor::Value, Status> response;
@@ -832,7 +638,7 @@ void SpecificationProcedure::MakeCredentialOptionsTest() {
   device_tracker_->CheckAndReport(response, "ignore unknown options");
 }
 
-void SpecificationProcedure::MakeCredentialPinAuthTest() {
+void TestSeries::MakeCredentialPinAuthTest() {
   std::string rp_id = "pinauth.example.com";
   Status returned_status;
   absl::variant<cbor::Value, Status> response;
@@ -917,8 +723,7 @@ void SpecificationProcedure::MakeCredentialPinAuthTest() {
   Reset();
 }
 
-void SpecificationProcedure::MakeCredentialMultipleKeysTest(
-    int num_credentials) {
+void TestSeries::MakeCredentialMultipleKeysTest(int num_credentials) {
   std::string rp_id = "multiple_keys.example.com";
   Status returned_status;
 
@@ -957,7 +762,7 @@ void SpecificationProcedure::MakeCredentialMultipleKeysTest(
   Reset();
 }
 
-void SpecificationProcedure::MakeCredentialPhysicalPresenceTest() {
+void TestSeries::MakeCredentialPhysicalPresenceTest() {
   // Currently, devices with displays are not supported.
   std::string rp_id = "presence.example.com";
   Status returned_status;
@@ -984,7 +789,7 @@ void SpecificationProcedure::MakeCredentialPhysicalPresenceTest() {
                                   "the asserted credential shouldn't exist");
 }
 
-void SpecificationProcedure::MakeCredentialDisplayNameEncodingTest() {
+void TestSeries::MakeCredentialDisplayNameEncodingTest() {
   std::string rp_id = "displayname.example.com";
   Status returned_status;
   absl::variant<cbor::Value, Status> response;
@@ -1046,7 +851,7 @@ void SpecificationProcedure::MakeCredentialDisplayNameEncodingTest() {
   }
 }
 
-void SpecificationProcedure::MakeCredentialHmacSecretTest() {
+void TestSeries::MakeCredentialHmacSecretTest() {
   if (!device_tracker_->HasExtension("hmac-secret")) {
     return;
   }
@@ -1068,7 +873,7 @@ void SpecificationProcedure::MakeCredentialHmacSecretTest() {
                                   "make credential with HMAC-secret extension");
 }
 
-void SpecificationProcedure::GetAssertionOptionsTest() {
+void TestSeries::GetAssertionOptionsTest() {
   std::string rp_id = "options.example.com";
   Status returned_status;
   absl::variant<cbor::Value, Status> response;
@@ -1146,7 +951,7 @@ void SpecificationProcedure::GetAssertionOptionsTest() {
   device_tracker_->CheckAndReport(response, "ignore unknown options");
 }
 
-void SpecificationProcedure::GetAssertionResidentialKeyTest() {
+void TestSeries::GetAssertionResidentialKeyTest() {
   std::string rp_id = "residential.example.com";
   Status returned_status;
   absl::variant<cbor::Value, Status> response;
@@ -1193,7 +998,7 @@ void SpecificationProcedure::GetAssertionResidentialKeyTest() {
                                   "this credential ID is fake");
 }
 
-void SpecificationProcedure::GetAssertionPinAuthTest() {
+void TestSeries::GetAssertionPinAuthTest() {
   std::string rp_id = "pinauth.example.com";
   Status returned_status;
   absl::variant<cbor::Value, Status> response;
@@ -1271,7 +1076,7 @@ void SpecificationProcedure::GetAssertionPinAuthTest() {
   Reset();
 }
 
-void SpecificationProcedure::GetAssertionPhysicalPresenceTest() {
+void TestSeries::GetAssertionPhysicalPresenceTest() {
   // Currently, devices with displays are not supported.
   std::string rp_id = "presence.example.com";
   Status returned_status;
@@ -1295,7 +1100,7 @@ void SpecificationProcedure::GetAssertionPhysicalPresenceTest() {
 
 // TODO(kaczmarczyck) check returned signature crypto
 
-void SpecificationProcedure::GetInfoTest() {
+void TestSeries::GetInfoTest() {
   absl::variant<cbor::Value, Status> response =
       fido2_commands::GetInfoPositiveTest(device_, device_tracker_);
   AssertResponse(response, "correct GetInfo response");
@@ -1348,7 +1153,7 @@ void SpecificationProcedure::GetInfoTest() {
       "support of PIN protocol version 1 is expected in this test suite");
 }
 
-void SpecificationProcedure::ClientPinRequirementsTest() {
+void TestSeries::ClientPinRequirementsTest() {
   Status returned_status;
 
   cbor::Value::BinaryValue too_short_pin_utf8 = {0x31, 0x32, 0x33};
@@ -1408,7 +1213,7 @@ void SpecificationProcedure::ClientPinRequirementsTest() {
   CheckPinByGetAuthToken();
 }
 
-void SpecificationProcedure::ClientPinRequirements2Point1Test() {
+void TestSeries::ClientPinRequirements2Point1Test() {
   if (!IsFido2Point1Complicant()) {
     return;
   }
@@ -1458,7 +1263,7 @@ void SpecificationProcedure::ClientPinRequirements2Point1Test() {
   CheckPinByGetAuthToken();
 }
 
-void SpecificationProcedure::ClientPinRetriesTest() {
+void TestSeries::ClientPinRetriesTest() {
   Status returned_status;
   Reset();
 
@@ -1555,7 +1360,7 @@ void SpecificationProcedure::ClientPinRetriesTest() {
   // TODO(kaczmarczyck) check optional powerCycleState
 }
 
-void SpecificationProcedure::Reset() {
+void TestSeries::Reset() {
   std::cout << "You have 10 seconds for the next touch after pressing enter.\n";
   PromptReplugAndInit();
   absl::variant<cbor::Value, Status> response =
@@ -1568,7 +1373,7 @@ void SpecificationProcedure::Reset() {
   auth_token_ = cbor::Value::BinaryValue();
 }
 
-void SpecificationProcedure::ResetDeletionTest() {
+void TestSeries::ResetDeletionTest() {
   std::string rp_id = "reset.example.com";
   Status returned_status;
   absl::variant<cbor::Value, Status> response;
@@ -1623,7 +1428,7 @@ void SpecificationProcedure::ResetDeletionTest() {
   Reset();
 }
 
-void SpecificationProcedure::ResetPhysicalPresenceTest() {
+void TestSeries::ResetPhysicalPresenceTest() {
   // Currently, devices with displays are not supported.
   std::string rp_id = "presence.example.com";
   Status returned_status;
@@ -1654,7 +1459,7 @@ void SpecificationProcedure::ResetPhysicalPresenceTest() {
       "reset not allowed more than 10 seconds after plugging in");
 }
 
-void SpecificationProcedure::PersistenceTest() {
+void TestSeries::PersistenceTest() {
   std::string rp_id = "persistence.example.com";
   absl::variant<cbor::Value, Status> response;
 
@@ -1690,7 +1495,7 @@ void SpecificationProcedure::PersistenceTest() {
   Reset();
 }
 
-void SpecificationProcedure::PromptReplugAndInit() {
+void TestSeries::PromptReplugAndInit() {
   std::cout << "Please replug the device, then hit enter." << std::endl;
   std::cin.ignore();
   CHECK(fido2_tests::Status::kErrNone == device_->Init())
@@ -1701,12 +1506,12 @@ void SpecificationProcedure::PromptReplugAndInit() {
   auth_token_ = cbor::Value::BinaryValue();
 }
 
-bool SpecificationProcedure::IsFido2Point1Complicant() {
+bool TestSeries::IsFido2Point1Complicant() {
   return device_tracker_->HasVersion("FIDO_2_1_PRE");
 }
 
-cbor::Value SpecificationProcedure::MakeTestCredential(
-    const std::string& rp_id, bool use_residential_key) {
+cbor::Value TestSeries::MakeTestCredential(const std::string& rp_id,
+                                           bool use_residential_key) {
   MakeCredentialCborBuilder test_builder;
   test_builder.AddDefaultsForRequiredFields(rp_id);
   test_builder.SetResidentialKeyOptions(use_residential_key);
@@ -1722,7 +1527,176 @@ cbor::Value SpecificationProcedure::MakeTestCredential(
   return std::move(absl::get<cbor::Value>(response));
 }
 
-int SpecificationProcedure::GetPinRetries() {
+void TestSeries::TestBadParameterTypes(Command command, CborBuilder* builder) {
+  for (const auto& item : type_examples_) {
+    if (item.first != cbor::Value::Type::MAP) {
+      Status returned_status = fido2_commands::GenericNegativeTest(
+          device_, item.second, command, false);
+      device_tracker_->CheckAndReport(
+          Status::kErrCborUnexpectedType, returned_status,
+          absl::StrCat("bad type ", CborTypeToString(item.first), " in ",
+                       CommandToString(command), " for the request"));
+    }
+  }
+
+  const cbor::Value map_cbor = builder->GetCbor();
+  for (const auto& map_entry : map_cbor.GetMap()) {
+    auto map_key = map_entry.first.Clone();
+    CHECK(map_key.is_unsigned()) << "map key not integer - TEST SUITE BUG";
+    auto map_value = map_entry.second.Clone();
+
+    // Replace the map value with another of wrong type. Maps and arrays get
+    // additional tests.
+    for (const auto& item : type_examples_) {
+      if (item.second.is_integer() && map_value.is_integer()) {
+        continue;
+      }
+      if (!map_value.is_type(item.first)) {
+        builder->SetArbitraryMapEntry(map_key.GetInteger(),
+                                      item.second.Clone());
+        Status returned_status = fido2_commands::GenericNegativeTest(
+            device_, builder->GetCbor(), command, false);
+        device_tracker_->CheckAndReport(
+            Status::kErrCborUnexpectedType, returned_status,
+            absl::StrCat("bad type ", CborTypeToString(item.first), " in ",
+                         CommandToString(command), " for key ",
+                         map_key.GetInteger()));
+      }
+    }
+
+    if (map_value.is_map()) {
+      TestBadParametersInInnerMap(command, builder, map_key.GetInteger(),
+                                  map_value.GetMap(), false);
+    }
+
+    // Checking types for the first element (assuming all have the same type).
+    if (map_value.is_array()) {
+      const cbor::Value& element = map_value.GetArray()[0];
+      TestBadParametersInInnerArray(command, builder, map_key.GetInteger(),
+                                    element);
+
+      if (element.is_map()) {
+        TestBadParametersInInnerMap(command, builder, map_key.GetInteger(),
+                                    element.GetMap(), true);
+      }
+    }
+
+    // Undo calls to builder->SetArbitraryMapEntry (including sub-functions).
+    builder->SetArbitraryMapEntry(std::move(map_key), std::move(map_value));
+  }
+}
+
+void TestSeries::TestMissingParameters(Command command, CborBuilder* builder) {
+  const cbor::Value map_cbor = builder->GetCbor();
+  for (const auto& parameter : map_cbor.GetMap()) {
+    auto map_key = parameter.first.Clone();
+    auto map_value = parameter.second.Clone();
+    builder->RemoveArbitraryMapEntry(map_key.Clone());
+    Status returned_status = fido2_commands::GenericNegativeTest(
+        device_, builder->GetCbor(), command, false);
+    device_tracker_->CheckAndReport(
+        Status::kErrMissingParameter, returned_status,
+        absl::StrCat("missing ", CborToString("key", map_key), " for command ",
+                     CommandToString(command)));
+    builder->SetArbitraryMapEntry(std::move(map_key), std::move(map_value));
+  }
+}
+
+void TestSeries::TestBadParametersInInnerMap(
+    Command command, CborBuilder* builder, int outer_map_key,
+    const cbor::Value::MapValue& inner_map, bool has_wrapping_array) {
+  cbor::Value::MapValue test_map;
+  for (const auto& inner_entry : inner_map) {
+    test_map[inner_entry.first.Clone()] = inner_entry.second.Clone();
+  }
+  for (const auto& inner_entry : inner_map) {
+    auto inner_key = inner_entry.first.Clone();
+    auto inner_value = inner_entry.second.Clone();
+
+    for (const auto& item : type_examples_) {
+      if (item.second.is_integer() && inner_value.is_integer()) {
+        continue;
+      }
+      if (!inner_value.is_type(item.first)) {
+        test_map[inner_key.Clone()] = item.second.Clone();
+        if (has_wrapping_array) {
+          cbor::Value::ArrayValue test_array;
+          test_array.push_back(cbor::Value(test_map));
+          builder->SetArbitraryMapEntry(outer_map_key, cbor::Value(test_array));
+        } else {
+          builder->SetArbitraryMapEntry(outer_map_key, cbor::Value(test_map));
+        }
+        Status returned_status = fido2_commands::GenericNegativeTest(
+            device_, builder->GetCbor(), command, false);
+        device_tracker_->CheckAndReport(
+            Status::kErrCborUnexpectedType, returned_status,
+            absl::StrCat("bad type ", CborTypeToString(item.first), " in ",
+                         CommandToString(command), " in ",
+                         CborToString("inner key", inner_key),
+                         " in array at map key ", outer_map_key));
+      }
+    }
+    test_map[std::move(inner_key)] = std::move(inner_value);
+  }
+}
+
+void TestSeries::TestBadParametersInInnerArray(
+    Command command, CborBuilder* builder, int outer_map_key,
+    const cbor::Value& array_element) {
+  for (const auto& item : type_examples_) {
+    if (item.second.is_integer() && array_element.is_integer()) {
+      continue;
+    }
+    if (!array_element.is_type(item.first)) {
+      cbor::Value::ArrayValue test_array;
+      test_array.push_back(array_element.Clone());
+      test_array.push_back(item.second.Clone());
+      builder->SetArbitraryMapEntry(outer_map_key, cbor::Value(test_array));
+      Status returned_status = fido2_commands::GenericNegativeTest(
+          device_, builder->GetCbor(), command, false);
+      device_tracker_->CheckAndReport(
+          Status::kErrCborUnexpectedType, returned_status,
+          absl::StrCat("bad type ", CborTypeToString(item.first), " in ",
+                       CommandToString(command),
+                       " in array element at map key ", outer_map_key));
+    }
+  }
+}
+
+void TestSeries::TestCredentialDescriptorsArrayForCborDepth(
+    Command command, CborBuilder* builder, int map_key,
+    const std::string& rp_id) {
+  Status returned_status;
+  absl::variant<cbor::Value, Status> response;
+
+  cbor::Value::BinaryValue cred_descriptor_id(32, 0xce);
+  for (const auto& item : type_examples_) {
+    if (item.first == cbor::Value::Type::ARRAY ||
+        item.first == cbor::Value::Type::MAP) {
+      cbor::Value::ArrayValue credential_descriptor_list;
+      cbor::Value::MapValue test_cred_descriptor;
+      test_cred_descriptor[cbor::Value("type")] = cbor::Value("public-key");
+      test_cred_descriptor[cbor::Value("id")] = cbor::Value(cred_descriptor_id);
+      cbor::Value::ArrayValue transports;
+      transports.push_back(cbor::Value("usb"));
+      transports.push_back(item.second.Clone());
+      test_cred_descriptor[cbor::Value("transports")] = cbor::Value(transports);
+      credential_descriptor_list.push_back(cbor::Value(test_cred_descriptor));
+      builder->SetArbitraryMapEntry(map_key,
+                                    cbor::Value(credential_descriptor_list));
+      returned_status = fido2_commands::GenericNegativeTest(
+          device_, builder->GetCbor(), command, false);
+      device_tracker_->CheckAndReport(
+          Status::kErrInvalidCbor, returned_status,
+          absl::StrCat("maximum CBOR nesting depth exceeded with ",
+                       CborTypeToString(item.first),
+                       " in credential descriptor transport list item in ",
+                       CommandToString(command), " for key ", map_key));
+    }
+  }
+}
+
+int TestSeries::GetPinRetries() {
   AuthenticatorClientPinCborBuilder get_retries_builder;
   get_retries_builder.AddDefaultsForGetPinRetries();
   absl::variant<cbor::Value, Status> response =
@@ -1739,7 +1713,7 @@ int SpecificationProcedure::GetPinRetries() {
   return ExtractPinRetries(absl::get<cbor::Value>(response));
 }
 
-void SpecificationProcedure::ComputeSharedSecret() {
+void TestSeries::ComputeSharedSecret() {
   AuthenticatorClientPinCborBuilder key_agreement_builder;
   key_agreement_builder.AddDefaultsForGetKeyAgreement();
   absl::variant<cbor::Value, Status> key_response =
@@ -1758,8 +1732,7 @@ void SpecificationProcedure::ComputeSharedSecret() {
       map_iter->second.GetMap(), &platform_cose_key_);
 }
 
-void SpecificationProcedure::SetPin(
-    const cbor::Value::BinaryValue& new_pin_utf8) {
+void TestSeries::SetPin(const cbor::Value::BinaryValue& new_pin_utf8) {
   if (platform_cose_key_.empty() || shared_secret_.empty()) {
     ComputeSharedSecret();
   }
@@ -1790,7 +1763,7 @@ void SpecificationProcedure::SetPin(
   PrintByteVector(new_pin_utf8);
 }
 
-Status SpecificationProcedure::AttemptSetPin(
+Status TestSeries::AttemptSetPin(
     const cbor::Value::BinaryValue& new_padded_pin) {
   if (platform_cose_key_.empty() || shared_secret_.empty()) {
     ComputeSharedSecret();
@@ -1808,8 +1781,7 @@ Status SpecificationProcedure::AttemptSetPin(
       device_, set_pin_builder.GetCbor(), false);
 }
 
-void SpecificationProcedure::ChangePin(
-    const cbor::Value::BinaryValue& new_pin_utf8) {
+void TestSeries::ChangePin(const cbor::Value::BinaryValue& new_pin_utf8) {
   SetPin();
   CHECK(new_pin_utf8.size() >= 4 && new_pin_utf8.size() <= 63)
       << "PIN requirements not fulfilled - TEST SUITE BUG";
@@ -1839,7 +1811,7 @@ void SpecificationProcedure::ChangePin(
   PrintByteVector(new_pin_utf8);
 }
 
-Status SpecificationProcedure::AttemptChangePin(
+Status TestSeries::AttemptChangePin(
     const cbor::Value::BinaryValue& new_padded_pin) {
   SetPin();
 
@@ -1862,7 +1834,7 @@ Status SpecificationProcedure::AttemptChangePin(
   return returned_status;
 }
 
-void SpecificationProcedure::GetAuthToken() {
+void TestSeries::GetAuthToken() {
   SetPin();
 
   AuthenticatorClientPinCborBuilder pin_token_builder;
@@ -1883,8 +1855,8 @@ void SpecificationProcedure::GetAuthToken() {
       crypto_utility::Aes256CbcDecrypt(shared_secret_, encrypted_token);
 }
 
-Status SpecificationProcedure::AttemptGetAuthToken(
-    const cbor::Value::BinaryValue& pin_utf8, bool redo_key_agreement) {
+Status TestSeries::AttemptGetAuthToken(const cbor::Value::BinaryValue& pin_utf8,
+                                       bool redo_key_agreement) {
   SetPin();
 
   AuthenticatorClientPinCborBuilder pin_token_builder;
@@ -1902,7 +1874,7 @@ Status SpecificationProcedure::AttemptGetAuthToken(
   return returned_status;
 }
 
-void SpecificationProcedure::CheckPinByGetAuthToken() {
+void TestSeries::CheckPinByGetAuthToken() {
   AuthenticatorClientPinCborBuilder pin_token_builder;
   cbor::Value::BinaryValue pin_hash_enc = crypto_utility::Aes256CbcEncrypt(
       shared_secret_, crypto_utility::LeftSha256Hash(pin_utf8_));
@@ -1918,7 +1890,7 @@ void SpecificationProcedure::CheckPinByGetAuthToken() {
   ComputeSharedSecret();
 }
 
-void SpecificationProcedure::CheckPinAbsenceByMakeCredential() {
+void TestSeries::CheckPinAbsenceByMakeCredential() {
   MakeCredentialCborBuilder pin_test_builder;
   pin_test_builder.AddDefaultsForRequiredFields("pin_absence.example.com");
 

--- a/src/test_series.h
+++ b/src/test_series.h
@@ -25,22 +25,25 @@
 
 namespace fido2_tests {
 
-// Systematically check all input parameters, if they follow the specification.
-// That includes enforcing the correct type of parameters, including members of
-// maps and arrays. It is very strict at checking unexpected additional
-// parameters, whenever the specification does not explicitly allow them. In
-// that case, it does not fail, but just prints a red message. The same goes for
-// checking optional parameters.
+// Contains tests for commands and input parameters. Commands tests usually
+// check all specified steps, and how the device acts then deviating from these
+// steps.
+// Input parameter tests strictly enforce correct type of parameters, including
+// members of maps and arrays. It is strict at checking unexpected additional
+// parameters, whenever the specification does not explicitly allow them.
+// In general, tests can also report observations or problems as side effects.
 // Example:
-//    fido2_tests::InputParameterTestSeries input_parameter_test_series =
-//        fido2_tests::InputParameterTestSeries(device, key_checker);
-//    input_parameter_test_series.MakeCredentialBadParameterTypesTest();
-class InputParameterTestSeries {
+//    fido2_tests::TestSeries test_series =
+//        fido2_tests::TestSeries(device, key_checker);
+//    test_series.MakeCredentialBadParameterTypesTest();
+class TestSeries {
  public:
-  // The ownership for device_tracker stays with the caller and must outlive
-  // the InputParameterTestSeries instance.
-  InputParameterTestSeries(DeviceInterface* device,
-                           DeviceTracker* device_tracker);
+  // The ownership for device and device_tracker stays with the caller and must
+  // outlive the TestSeries instance.
+  TestSeries(DeviceInterface* device, DeviceTracker* device_tracker);
+
+  // Tests for MakeCredential.
+
   // Check if MakeCredential accepts different CBOR types for its parameters.
   void MakeCredentialBadParameterTypesTest();
   // Check if MakeCredential accepts leaving out one of the required parameters.
@@ -50,17 +53,58 @@ class InputParameterTestSeries {
   // Check the optional map entries of the user entity.
   void MakeCredentialUserEntityTest();
   // Check the inner array transport elements of the exclude list.
-  void MakeCredentialExcludeListTest();
+  void MakeCredentialExcludeListCredentialDescriptorTest();
   // Check if unknown extensions are accepted.
   void MakeCredentialExtensionsTest();
+  // Tests if the authenticator checks the exclude list properly.
+  void MakeCredentialExcludeListTest();
+  // Tests correct behavior with different COSE algorithms. Tests non-existing
+  // algorithm identifier and type.
+  void MakeCredentialCoseAlgorithmTest();
+  // Tests correct behavior when setting rk, up and uv.
+  void MakeCredentialOptionsTest();
+  // Tests if the PIN is correctly enforced. Resets afterwards to unset the PIN.
+  void MakeCredentialPinAuthTest();
+  // Tests correct behavior when creating multiple keys. This test attempts to
+  // create num_credentials credentials, stopping before that if the internal
+  // key store is full. It resets afterwards to clear the storage.
+  void MakeCredentialMultipleKeysTest(int num_credentials);
+  // Tests if the key hardware actually interacts with a user. This test can not
+  // be performed automatically, but requires tester feedback.
+  void MakeCredentialPhysicalPresenceTest();
+  // Tests if the user name is resistent to long inputs and bad UTF8.
+  void MakeCredentialDisplayNameEncodingTest();
+  // Tests if the HMAC-secret extension works properly.
+  void MakeCredentialHmacSecretTest();
+
+  // Tests for GetAssertion.
+
   // Check if GetAssertion accepts different CBOR types for its parameters.
   void GetAssertionBadParameterTypesTest();
   // Check if GetAssertion accepts leaving out one of the required parameters.
   void GetAssertionMissingParameterTest();
   // Check the inner array transport elements of the allow list.
-  void GetAssertionAllowListTest();
+  void GetAssertionAllowListCredentialDescriptorTest();
   // Check if unknown extensions are accepted.
   void GetAssertionExtensionsTest();
+  // Tests correct behavior when setting rk, up and uv.
+  void GetAssertionOptionsTest();
+  // Tests correct differentiation between residential and non-residential.
+  void GetAssertionResidentialKeyTest();
+  // Tests if the PIN is correctly enforced. Resets afterwards to unset the PIN.
+  void GetAssertionPinAuthTest();
+  // Tests if the key hardware actually interacts with a user. This test can not
+  // be performed automatically, but requires tester feedback.
+  void GetAssertionPhysicalPresenceTest();
+
+  // Tests for GetInfo.
+
+  // Checks if the GetInfo command has valid output implicitly. Also checks for
+  // support of PIN protocol version 1, because it is used throughout all tests.
+  void GetInfoTest();
+
+  // Tests for ClientPin.
+
   // Check the input parameters of the client PIN subcommand getPinRetries.
   void ClientPinGetPinRetriesTest();
   // Check the input parameters of the client PIN subcommand getKeyAgreement.
@@ -78,13 +122,47 @@ class InputParameterTestSeries {
   // Check the input parameters of the client PIN subcommand getUVRetries.
   // Requires CTAP 2.1, returns otherwise.
   void ClientPinGetUVRetriesTest();
+  // Tests if the PIN minimum and maximum length are enforced correctly for the
+  // SetPin and ChangePin command. Resets the device on failed tests so that the
+  // following test will still find a valid state. Might end with the device
+  // having a PIN set.
+  void ClientPinRequirementsTest();
+  // Tests PIN protocol requirements introduced in CTAP 2.1. This includes
+  // testing different padding lengths for SetPin and ChangePin. Resets the
+  // device before tests and on failed tests. Might end with the device having a
+  // PIN set.
+  void ClientPinRequirements2Point1Test();
+  // Tests if retries decrement properly and respond with correct error codes.
+  // Creates a PIN if necessary. Resets the device at the beginning and the end.
+  void ClientPinRetriesTest();
+
+  // Tests for Reset.
+
+  // Only tests the returned status code, just resets the authenticator.
+  // Replugging the device before calling the function is necessary.
+  void Reset();
+  // Tests if the state on the device is wiped out.
+  // Replugging the device before calling the function is necessary.
+  void ResetDeletionTest();
+  // Tests if requirements for resetting are enforced.
+  void ResetPhysicalPresenceTest();
+  // Tests if the state is persistent when being replugged. This includes
+  // credentials and the PIN retries.
+  void PersistenceTest();
 
  private:
+  // Prompts the user to replug the device which is required before operations
+  // that need a power cycle (i.e. resetting). The Init will then handle device
+  // initilalization, regardless of the current state of the device.
+  void PromptReplugAndInit();
   // TODO(#16) replace version string with FIDO_2_1 when specification is final
   bool IsFido2Point1Complicant();
   // Makes a credential for all tests that require one, for example assertions.
   cbor::Value MakeTestCredential(const std::string& rp_id,
                                  bool use_residential_key);
+
+  // The following helper functions are used to test input parameters.
+
   // Tries to insert types other than the correct one into the CBOR builder.
   // Make sure to pass the appropriate CborBuilder for your command. The correct
   // types are inferred through the currently present builder entries. The tests
@@ -122,98 +200,8 @@ class InputParameterTestSeries {
                                                   CborBuilder* builder,
                                                   int map_key,
                                                   const std::string& rp_id);
-  DeviceInterface* device_;
-  DeviceTracker* device_tracker_;
-  // These are arbitrary example values for each CBOR type.
-  std::map<cbor::Value::Type, cbor::Value> type_examples_;
-  // This map is a subset of the type_examples_. Since CBOR implementations do
-  // not need to allow all CBOR types as map keys, testing on all of them for
-  // map keys might produce different error codes. Since we currently enforce
-  // a specific error code, use this subset of CBOR types for all tests on map
-  // keys. Allowed map keys might depend on the CBOR parser implementation.
-  // The specification only states: "Note that this rule allows maps that have
-  // keys of different types, even though that is probably a bad practice that
-  // could lead to errors in some canonicalization implementations."
-  std::map<cbor::Value::Type, cbor::Value> map_key_examples_;
-  // This is an example of an EC cose key map for client PIN operations.
-  cbor::Value::MapValue cose_key_example_;
-};
 
-class SpecificationProcedure {
- public:
-  // The ownership for device_tracker stays with the caller and must outlive
-  // the SpecificationProcedure instance.
-  SpecificationProcedure(DeviceInterface* device,
-                         DeviceTracker* device_tracker);
-  // Tests if the authenticator checks the exclude list properly.
-  void MakeCredentialExcludeListTest();
-  // Tests correct behavior with different COSE algorithms. Tests non-existing
-  // algorithm identifier and type.
-  void MakeCredentialCoseAlgorithmTest();
-  // Tests correct behavior when setting rk, up and uv.
-  void MakeCredentialOptionsTest();
-  // Tests if the PIN is correctly enforced. Resets afterwards to unset the PIN.
-  void MakeCredentialPinAuthTest();
-  // Tests correct behavior when creating multiple keys. This test attempts to
-  // create num_credentials credentials, stopping before that if the internal
-  // key store is full. It resets afterwards to clear the storage.
-  void MakeCredentialMultipleKeysTest(int num_credentials);
-  // Tests if the key hardware actually interacts with a user. This test can not
-  // be performed automatically, but requires tester feedback.
-  void MakeCredentialPhysicalPresenceTest();
-  // Tests if the user name is resistent to long inputs and bad UTF8.
-  void MakeCredentialDisplayNameEncodingTest();
-  // Tests if the HMAC-secret extension works properly.
-  void MakeCredentialHmacSecretTest();
-  // Tests correct behavior when setting rk, up and uv.
-  void GetAssertionOptionsTest();
-  // Tests correct differentiation between residential and non-residential.
-  void GetAssertionResidentialKeyTest();
-  // Tests if the PIN is correctly enforced. Resets afterwards to unset the PIN.
-  void GetAssertionPinAuthTest();
-  // Tests if the key hardware actually interacts with a user. This test can not
-  // be performed automatically, but requires tester feedback.
-  void GetAssertionPhysicalPresenceTest();
-  // Checks if the GetInfo command has valid output implicitly. Also checks for
-  // support of PIN protocol version 1, because it is used throughout all tests.
-  void GetInfoTest();
-  // Tests if the PIN minimum and maximum length are enforced correctly for the
-  // SetPin and ChangePin command. Resets the device on failed tests so that the
-  // following test will still find a valid state. Might end with the device
-  // having a PIN set.
-  void ClientPinRequirementsTest();
-  // Tests PIN protocol requirements introduced in CTAP 2.1. This includes
-  // testing different padding lengths for SetPin and ChangePin. Resets the
-  // device before tests and on failed tests. Might end with the device having a
-  // PIN set.
-  void ClientPinRequirements2Point1Test();
-  // Tests if retries decrement properly and respond with correct error codes.
-  // Creates a PIN if necessary. Resets the device at the beginning and the end.
-  void ClientPinRetriesTest();
-  // Only tests the returned status code, just resets the authenticator.
-  // Replugging the device before calling the function is necessary.
-  void Reset();
-  // Tests if the state on the device is wiped out.
-  // Replugging the device before calling the function is necessary.
-  void ResetDeletionTest();
-  // Tests if requirements for resetting are enforced.
-  void ResetPhysicalPresenceTest();
-  // Tests if the state is persistent when being replugged. This includes
-  // credentials and the PIN retries.
-  void PersistenceTest();
-
- private:
-  // Prompts the user to replug the device which is required before operations
-  // that need a power cycle (i.e. resetting). The Init will then handle device
-  // initilalization, regardless of the current state of the device.
-  void PromptReplugAndInit();
-  // Returns if the device supports CTAP 2.1. Currently looks for FIDO_2_1_PRE.
-  // TODO(#16) replace version string with FIDO_2_1 when specification is final
-  bool IsFido2Point1Complicant();
-  // Makes a credential for all tests that require one, for example assertions.
-  // Works with or without a PIN being set.
-  cbor::Value MakeTestCredential(const std::string& rp_id,
-                                 bool use_residential_key);
+  // The following helper functions are used to test command behaviour.
 
   // Gets and checks the PIN retry counter response from the authenticator.
   int GetPinRetries();
@@ -259,15 +247,29 @@ class SpecificationProcedure {
   // of Make Credential, this kind of misbehavior would be caught in another
   // test.
   void CheckPinAbsenceByMakeCredential();
+
   DeviceInterface* device_;
   DeviceTracker* device_tracker_;
+  // These are arbitrary example values for each CBOR type.
+  std::map<cbor::Value::Type, cbor::Value> type_examples_;
+  // This map is a subset of the type_examples_. Since CBOR implementations do
+  // not need to allow all CBOR types as map keys, testing on all of them for
+  // map keys might produce different error codes. Since we currently enforce
+  // a specific error code, use this subset of CBOR types for all tests on map
+  // keys. Allowed map keys might depend on the CBOR parser implementation.
+  // The specification only states: "Note that this rule allows maps that have
+  // keys of different types, even though that is probably a bad practice that
+  // could lead to errors in some canonicalization implementations."
+  std::map<cbor::Value::Type, cbor::Value> map_key_examples_;
+  // This is an example of an EC cose key map for client PIN operations.
+  cbor::Value::MapValue cose_key_example_;
+  // This is an example PIN that should be different from the real PIN.
+  const cbor::Value::BinaryValue bad_pin_;
   // The PIN is persistent, the other state is kept for a power cycle.
   cbor::Value::MapValue platform_cose_key_;
   cbor::Value::BinaryValue shared_secret_;
   cbor::Value::BinaryValue pin_utf8_;
   cbor::Value::BinaryValue auth_token_;
-  // This is an example PIN that should be different from the real PIN.
-  const cbor::Value::BinaryValue bad_pin_;
 };
 
 }  // namespace fido2_tests


### PR DESCRIPTION
As a preparation to split tests up into multiple files, we merge them into one class. This was prepared by the introduction of the `DeviceTracker` and hinted at in #21.