### PR TITLE
Move state in test series to new class

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -124,6 +124,23 @@ cc_library(
 )
 
 cc_library(
+    name = "command_state",
+    srcs = ["src/command_state.cc"],
+    hdrs = ["src/command_state.h"],
+    deps = [
+        ":constants",
+        ":crypto_utility",
+        ":cbor_builders",
+        ":device_interface",
+        ":device_tracker",
+        ":fido2_commands",
+        "//third_party/chromium_components_cbor:cbor",
+        "@com_google_absl//absl/types:variant",
+        "@com_google_glog//:glog",
+    ],
+)
+
+cc_library(
     name = "parameter_check",
     srcs = ["src/parameter_check.cc"],
     hdrs = ["src/parameter_check.h"],
@@ -138,6 +155,7 @@ cc_binary(
     name = "fido2_conformance",
     srcs = ["src/fido2_conformance_main.cc"],
     deps = [
+        ":command_state",
         ":device_tracker",
         ":hid_device",
         ":parameter_check",

--- a/src/command_state.cc
+++ b/src/command_state.cc
@@ -1,0 +1,284 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/command_state.h"
+
+#include <iostream>
+
+#include "absl/types/variant.h"
+#include "src/cbor_builders.h"
+#include "src/constants.h"
+#include "src/crypto_utility.h"
+#include "src/fido2_commands.h"
+
+namespace fido2_tests {
+namespace {
+constexpr size_t kPinByteLength = 64;
+
+void AssertResponse(const absl::variant<cbor::Value, Status>& returned_variant,
+                    const std::string& hint) {
+  CHECK(!absl::holds_alternative<Status>(returned_variant))
+      << "Failed test setup: " << hint << " - returned status code "
+      << StatusToString(absl::get<Status>(returned_variant));
+}
+}  // namespace
+
+#define OK_OR_RETURN(x)               \
+  ({                                  \
+    Status status = (x);              \
+    if (status != Status::kErrNone) { \
+      return status;                  \
+    }                                 \
+  })
+
+CommandState::CommandState(DeviceInterface* device,
+                           DeviceTracker* device_tracker)
+    : device_(device), device_tracker_(device_tracker) {
+  Reset();
+  absl::variant<cbor::Value, Status> response =
+      fido2_commands::GetInfoPositiveTest(device_, device_tracker_);
+  AssertResponse(response, "GetInfo");
+}
+
+void CommandState::PromptReplugAndInit() {
+  std::cout << "Please replug the device, then hit enter." << std::endl;
+  std::cin.ignore();
+  CHECK(fido2_tests::Status::kErrNone == device_->Init())
+      << "CTAPHID initialization failed";
+
+  platform_cose_key_ = cbor::Value::MapValue();
+  shared_secret_ = cbor::Value::BinaryValue();
+  auth_token_ = cbor::Value::BinaryValue();
+}
+
+void CommandState::Reset() {
+  std::cout << "You have 10 seconds for the next touch after pressing enter.\n";
+  PromptReplugAndInit();
+  absl::variant<cbor::Value, Status> response =
+      fido2_commands::ResetPositiveTest(device_);
+  AssertResponse(response, "Reset");
+
+  platform_cose_key_ = cbor::Value::MapValue();
+  shared_secret_ = cbor::Value::BinaryValue();
+  pin_utf8_ = cbor::Value::BinaryValue();
+  auth_token_ = cbor::Value::BinaryValue();
+}
+
+void CommandState::Prepare(bool set_uv) {
+  if (set_uv) {
+    if (pin_utf8_.empty()) {
+      AssertResponse(SetPin(), "set PIN");
+    }
+  } else {
+    if (!pin_utf8_.empty()) {
+      Reset();
+    }
+  }
+}
+
+absl::variant<cbor::Value, Status> CommandState::MakeTestCredential(
+    const std::string& rp_id, bool use_residential_key) {
+  MakeCredentialCborBuilder test_builder;
+  test_builder.AddDefaultsForRequiredFields(rp_id);
+  test_builder.SetResidentialKeyOptions(use_residential_key);
+  if (!auth_token_.empty()) {
+    test_builder.SetDefaultPinUvAuthParam(auth_token_);
+    test_builder.SetDefaultPinUvAuthProtocol();
+  }
+
+  return fido2_commands::MakeCredentialPositiveTest(device_, device_tracker_,
+                                                    test_builder.GetCbor());
+}
+
+Status CommandState::ComputeSharedSecret() {
+  AuthenticatorClientPinCborBuilder key_agreement_builder;
+  key_agreement_builder.AddDefaultsForGetKeyAgreement();
+  absl::variant<cbor::Value, Status> key_response =
+      fido2_commands::AuthenticatorClientPinPositiveTest(
+          device_, device_tracker_, key_agreement_builder.GetCbor());
+  if (absl::holds_alternative<Status>(key_response)) {
+    device_tracker_->AddProblem("GetKeyAgreement failed");
+    return absl::get<Status>(key_response);
+  }
+
+  const auto& key_agreement_map = absl::get<cbor::Value>(key_response).GetMap();
+  auto map_iter = key_agreement_map.find(cbor::Value(1));
+  shared_secret_ = crypto_utility::CompleteEcdhHandshake(
+      map_iter->second.GetMap(), &platform_cose_key_);
+  return Status::kErrNone;
+}
+
+Status CommandState::SetPin(const cbor::Value::BinaryValue& new_pin_utf8) {
+  if (platform_cose_key_.empty() || shared_secret_.empty()) {
+    OK_OR_RETURN(ComputeSharedSecret());
+  }
+  if (!pin_utf8_.empty()) {
+    return Status::kErrNone;
+  }
+  CHECK(new_pin_utf8.size() >= 4 && new_pin_utf8.size() <= 63)
+      << "PIN requirements not fulfilled - TEST SUITE BUG";
+
+  cbor::Value::BinaryValue new_padded_pin(kPinByteLength, 0);
+  std::copy(new_pin_utf8.begin(), new_pin_utf8.end(), new_padded_pin.begin());
+  cbor::Value::BinaryValue new_pin_enc =
+      crypto_utility::Aes256CbcEncrypt(shared_secret_, new_padded_pin);
+  cbor::Value::BinaryValue pin_auth =
+      crypto_utility::LeftHmacSha256(shared_secret_, new_pin_enc);
+
+  AuthenticatorClientPinCborBuilder set_pin_builder;
+  set_pin_builder.AddDefaultsForSetPin(platform_cose_key_, pin_auth,
+                                       new_pin_enc);
+  absl::variant<cbor::Value, Status> set_pin_response =
+      fido2_commands::AuthenticatorClientPinPositiveTest(
+          device_, device_tracker_, set_pin_builder.GetCbor());
+  if (absl::holds_alternative<Status>(set_pin_response)) {
+    device_tracker_->AddProblem("SetPin failed.");
+    // Failed PIN checks reset the key agreement, keep the state consistent.
+    OK_OR_RETURN(ComputeSharedSecret());
+    return absl::get<Status>(set_pin_response);
+  } else {
+    pin_utf8_ = new_pin_utf8;
+    return Status::kErrNone;
+  }
+}
+
+Status CommandState::AttemptSetPin(
+    const cbor::Value::BinaryValue& new_padded_pin) {
+  if (platform_cose_key_.empty() || shared_secret_.empty()) {
+    OK_OR_RETURN(ComputeSharedSecret());
+  }
+
+  cbor::Value::BinaryValue new_pin_enc =
+      crypto_utility::Aes256CbcEncrypt(shared_secret_, new_padded_pin);
+  cbor::Value::BinaryValue pin_auth =
+      crypto_utility::LeftHmacSha256(shared_secret_, new_pin_enc);
+
+  AuthenticatorClientPinCborBuilder set_pin_builder;
+  set_pin_builder.AddDefaultsForSetPin(platform_cose_key_, pin_auth,
+                                       new_pin_enc);
+  return fido2_commands::AuthenticatorClientPinNegativeTest(
+      device_, set_pin_builder.GetCbor(), false);
+}
+
+Status CommandState::ChangePin(const cbor::Value::BinaryValue& new_pin_utf8) {
+  OK_OR_RETURN(SetPin());
+  CHECK(new_pin_utf8.size() >= 4 && new_pin_utf8.size() <= 63)
+      << "PIN requirements not fulfilled - TEST SUITE BUG";
+
+  cbor::Value::BinaryValue new_padded_pin(kPinByteLength, 0);
+  std::copy(new_pin_utf8.begin(), new_pin_utf8.end(), new_padded_pin.begin());
+  cbor::Value::BinaryValue pin_hash_enc = crypto_utility::Aes256CbcEncrypt(
+      shared_secret_, crypto_utility::LeftSha256Hash(pin_utf8_));
+  cbor::Value::BinaryValue new_pin_enc =
+      crypto_utility::Aes256CbcEncrypt(shared_secret_, new_padded_pin);
+  cbor::Value::BinaryValue auth_data(new_pin_enc);
+  auth_data.insert(auth_data.end(), pin_hash_enc.begin(), pin_hash_enc.end());
+  cbor::Value::BinaryValue pin_auth =
+      crypto_utility::LeftHmacSha256(shared_secret_, auth_data);
+
+  AuthenticatorClientPinCborBuilder change_pin_builder;
+  change_pin_builder.AddDefaultsForChangePin(platform_cose_key_, pin_auth,
+                                             new_pin_enc, pin_hash_enc);
+  absl::variant<cbor::Value, Status> change_pin_response =
+      fido2_commands::AuthenticatorClientPinPositiveTest(
+          device_, device_tracker_, change_pin_builder.GetCbor());
+
+  if (absl::holds_alternative<Status>(change_pin_response)) {
+    device_tracker_->AddProblem("ChangePin failed.");
+    // Failed PIN checks reset the key agreement, keep the state consistent.
+    OK_OR_RETURN(ComputeSharedSecret());
+    return absl::get<Status>(change_pin_response);
+  } else {
+    pin_utf8_ = new_pin_utf8;
+    return Status::kErrNone;
+  }
+}
+
+Status CommandState::AttemptChangePin(
+    const cbor::Value::BinaryValue& new_padded_pin) {
+  OK_OR_RETURN(SetPin());
+
+  cbor::Value::BinaryValue pin_hash_enc = crypto_utility::Aes256CbcEncrypt(
+      shared_secret_, crypto_utility::LeftSha256Hash(pin_utf8_));
+  cbor::Value::BinaryValue new_pin_enc =
+      crypto_utility::Aes256CbcEncrypt(shared_secret_, new_padded_pin);
+  cbor::Value::BinaryValue auth_data(new_pin_enc);
+  auth_data.insert(auth_data.end(), pin_hash_enc.begin(), pin_hash_enc.end());
+  cbor::Value::BinaryValue pin_auth =
+      crypto_utility::LeftHmacSha256(shared_secret_, auth_data);
+
+  AuthenticatorClientPinCborBuilder change_pin_builder;
+  change_pin_builder.AddDefaultsForChangePin(platform_cose_key_, pin_auth,
+                                             new_pin_enc, pin_hash_enc);
+  Status returned_status = fido2_commands::AuthenticatorClientPinNegativeTest(
+      device_, change_pin_builder.GetCbor(), false);
+  // Failed PIN checks reset the key agreement, keep the state consistent.
+  OK_OR_RETURN(ComputeSharedSecret());
+  return returned_status;
+}
+
+Status CommandState::GetAuthToken(bool set_pin_if_necessary) {
+  OK_OR_RETURN(SetPin());
+
+  AuthenticatorClientPinCborBuilder pin_token_builder;
+  cbor::Value::BinaryValue pin_hash_enc = crypto_utility::Aes256CbcEncrypt(
+      shared_secret_, crypto_utility::LeftSha256Hash(pin_utf8_));
+  pin_token_builder.AddDefaultsForGetPinUvAuthTokenUsingPin(platform_cose_key_,
+                                                            pin_hash_enc);
+  absl::variant<cbor::Value, Status> pin_token_response =
+      fido2_commands::AuthenticatorClientPinPositiveTest(
+          device_, device_tracker_, pin_token_builder.GetCbor());
+
+  if (absl::holds_alternative<Status>(pin_token_response)) {
+    if (set_pin_if_necessary) {
+      // This is acceptable behaviour if not set up properly.
+      device_tracker_->AddProblem("GetAuthToken failed.");
+    }
+    // Failed PIN checks reset the key agreement, keep the state consistent.
+    OK_OR_RETURN(ComputeSharedSecret());
+    return absl::get<Status>(pin_token_response);
+  } else {
+    const auto& pin_token_map =
+        absl::get<cbor::Value>(pin_token_response).GetMap();
+    auto map_iter = pin_token_map.find(cbor::Value(2));
+    cbor::Value::BinaryValue encrypted_token = map_iter->second.GetBytestring();
+    auth_token_ =
+        crypto_utility::Aes256CbcDecrypt(shared_secret_, encrypted_token);
+    return Status::kErrNone;
+  }
+}
+
+Status CommandState::AttemptGetAuthToken(
+    const cbor::Value::BinaryValue& pin_utf8, bool redo_key_agreement) {
+  OK_OR_RETURN(SetPin());
+
+  AuthenticatorClientPinCborBuilder pin_token_builder;
+  cbor::Value::BinaryValue pin_hash_enc = crypto_utility::Aes256CbcEncrypt(
+      shared_secret_, crypto_utility::LeftSha256Hash(pin_utf8));
+  pin_token_builder.AddDefaultsForGetPinUvAuthTokenUsingPin(platform_cose_key_,
+                                                            pin_hash_enc);
+  Status returned_status = fido2_commands::AuthenticatorClientPinNegativeTest(
+      device_, pin_token_builder.GetCbor(), false);
+  if (redo_key_agreement) {
+    // Failed PIN checks reset the key agreement, keep the state consistent.
+    OK_OR_RETURN(ComputeSharedSecret());
+  }
+  return returned_status;
+}
+
+cbor::Value::BinaryValue CommandState::GetCurrentAuthToken() {
+  return auth_token_;
+}
+
+}  // namespace fido2_tests

--- a/src/command_state.h
+++ b/src/command_state.h
@@ -1,0 +1,97 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMMAND_STATE_H_
+#define COMMAND_STATE_H_
+
+#include "src/device_interface.h"
+#include "src/device_tracker.h"
+#include "third_party/chromium_components_cbor/values.h"
+
+namespace fido2_tests {
+
+// Tracks the internal state of a security key.
+//
+// This tool faces a tradeoff between usability and reproducibility of tests. To
+// avoid a Reset command after each test, tracking the state of the security key
+// helps reducing the number of replugs and touches for user presence.
+class CommandState {
+ public:
+  // Creates the state to a freshly reset security key. Assumes an initialized
+  // device, and calls Reset and GetInfo to synchronize and initialize the
+  // device_tracker.
+  CommandState(DeviceInterface* device, DeviceTracker* device_tracker);
+  // Prompts the user to replug the device which is required before operations
+  // that need a power cycle (i.e. resetting). The Init will then handle device
+  // initilalization, regardless of the current state of the device.
+  void PromptReplugAndInit();
+  // Calls the Reset command to reset the state of the device.
+  void Reset();
+  // Takes actions until the state is neutral. Call this function before
+  // executing a test. If your test needs user verification to work, use set_uv.
+  void Prepare(bool set_uv = false);
+  // Makes a credential for all tests that require one, for example assertions.
+  // Works with or without a PIN being set.
+  absl::variant<cbor::Value, Status> MakeTestCredential(
+      const std::string& rp_id, bool use_residential_key);
+  // Compute the shared secret between authenticator and platform. Sets the
+  // argument platform_cose_key to the EC key used during the transaction.
+  Status ComputeSharedSecret();
+  // Sets the PIN to the value specified in new_pin_utf8. Performs key agreement
+  // if not already done. Safe to call multiple times, and only talks to the
+  // authenticator if there is no PIN already. Defaults to 1234 if nothing else
+  // is set. Fails if the PIN requirements are not satisfied.
+  Status SetPin(const cbor::Value::BinaryValue& new_pin_utf8 = {0x31, 0x32,
+                                                                0x33, 0x34});
+  // Calls the SetPin command with the given padded PIN. Fails if the length is
+  // not a multiple of the AES block size. Returns the command's status code.
+  // Performs key agreement if not already done.
+  Status AttemptSetPin(const cbor::Value::BinaryValue& new_padded_pin);
+  // Changes the current PIN to new_pin_utf8. Fails if the PIN requirements are
+  // not satisfied. Creates a PIN if not already done.
+  Status ChangePin(const cbor::Value::BinaryValue& new_pin_utf8);
+  // Calls the ChangePin command with the given padded PIN, using the currently
+  // set PIN. Fails if the length is not a multiple of the AES block size.
+  // Returns the command's status code. Creates a PIN if not already done.
+  Status AttemptChangePin(const cbor::Value::BinaryValue& new_padded_pin);
+  // Returns a PIN Auth token valid for this power cycle from the authenticator.
+  // Sets the PIN to 1234 if no PIN exists and set_pin_if_necessary is true.
+  Status GetAuthToken(bool set_pin_if_necessary = true);
+  // Calls the GetAuthToken command with the given PIN. Creates a PIN if
+  // not already done. The tested PIN defaults to 1234, which should work with
+  // SetPin's default. Returns the command's status code. If redo_key_agreement
+  // is true, it brings the shared_secret back to a valid state. This is
+  // necessary because authenticators reset the key agreement on failed PIN
+  // hash checks. Setting redo_key_agreement is only used for specific failure
+  // mode tests.
+  Status AttemptGetAuthToken(
+      const cbor::Value::BinaryValue& pin_utf8 = {0x31, 0x32, 0x33, 0x34},
+      bool redo_key_agreement = true);
+  // Returns the currently stored auth token. This value represents what should
+  // be the internal state of the device right now (or is empty if unknown).
+  cbor::Value::BinaryValue GetCurrentAuthToken();
+
+ private:
+  DeviceInterface* device_;
+  DeviceTracker* device_tracker_;
+  // The PIN is persistent, the other state is kept for a power cycle.
+  cbor::Value::MapValue platform_cose_key_;
+  cbor::Value::BinaryValue shared_secret_;
+  cbor::Value::BinaryValue pin_utf8_;
+  cbor::Value::BinaryValue auth_token_;
+};
+
+}  // namespace fido2_tests
+
+#endif  // COMMAND_STATE_H_

--- a/src/device_interface.h
+++ b/src/device_interface.h
@@ -15,6 +15,8 @@
 #ifndef DEVICE_INTERFACE_H_
 #define DEVICE_INTERFACE_H_
 
+#include <vector>
+
 #include "src/constants.h"
 
 namespace fido2_tests {

--- a/src/fido2_conformance_main.cc
+++ b/src/fido2_conformance_main.cc
@@ -16,6 +16,7 @@
 
 #include "gflags/gflags.h"
 #include "glog/logging.h"
+#include "src/command_state.h"
 #include "src/constants.h"
 #include "src/device_tracker.h"
 #include "src/hid/hid_device.h"
@@ -53,13 +54,11 @@ int main(int argc, char** argv) {
   CHECK(fido2_tests::Status::kErrNone == device->Init())
       << "CTAPHID initialization failed";
   device->Wink();
+  // Resets and initializes.
+  fido2_tests::CommandState command_state(device.get(), &tracker);
 
   fido2_tests::TestSeries test_series =
-      fido2_tests::TestSeries(device.get(), &tracker);
-
-  test_series.Reset();
-  // You need to execute GetInfo first to initialize the tracker.
-  test_series.GetInfoTest();
+      fido2_tests::TestSeries(device.get(), &tracker, &command_state);
 
   test_series.MakeCredentialBadParameterTypesTest();
   test_series.MakeCredentialMissingParameterTest();
@@ -95,6 +94,8 @@ int main(int argc, char** argv) {
   test_series.GetAssertionResidentialKeyTest();
   test_series.GetAssertionPinAuthTest();
   test_series.GetAssertionPhysicalPresenceTest();
+
+  test_series.GetInfoTest();
 
   test_series.ClientPinRequirementsTest();
   test_series.ClientPinRequirements2Point1Test();

--- a/src/tests/BUILD
+++ b/src/tests/BUILD
@@ -30,6 +30,7 @@ cc_library(
     ],
     deps = [
         "//:cbor_builders",
+        "//:command_state",
         "//:crypto_utility",
         "//:device_interface",
         "//:device_tracker",

--- a/src/tests/test_client_pin.cc
+++ b/src/tests/test_client_pin.cc
@@ -98,24 +98,24 @@ void TestSeries::ClientPinRequirementsTest() {
   for (size_t i = 0; i < too_short_pin_utf8.size(); ++i) {
     too_short_padded_pin[i] = too_short_pin_utf8[i];
   }
-  returned_status = AttemptSetPin(too_short_padded_pin);
+  returned_status = command_state_->AttemptSetPin(too_short_padded_pin);
   device_tracker_->CheckAndReport(Status::kErrPinPolicyViolation,
                                   returned_status,
                                   "reject to set a PIN of length < 4");
   CheckPinAbsenceByMakeCredential();
   if (returned_status == Status::kErrNone) {
-    Reset();
+    command_state_->Reset();
   }
 
   cbor::Value::BinaryValue too_long_padded_pin =
       cbor::Value::BinaryValue(64, 0x30);
-  returned_status = AttemptSetPin(too_long_padded_pin);
+  returned_status = command_state_->AttemptSetPin(too_long_padded_pin);
   device_tracker_->CheckAndReport(Status::kErrPinPolicyViolation,
                                   returned_status,
                                   "reject to set a PIN of length > 63");
   CheckPinAbsenceByMakeCredential();
   if (returned_status == Status::kErrNone) {
-    Reset();
+    command_state_->Reset();
   }
 
   // The minimum length is 4, but the authenticator can enforce more, so only
@@ -123,29 +123,33 @@ void TestSeries::ClientPinRequirementsTest() {
   // TODO(kaczmarczyck) use minimum PIN length from GetInfo
   cbor::Value::BinaryValue maximum_pin_utf8 =
       cbor::Value::BinaryValue(63, 0x30);
-  SetPin(maximum_pin_utf8);
+  device_tracker_->CheckAndReport(Status::kErrNone,
+                                  command_state_->SetPin(maximum_pin_utf8),
+                                  "set PIN of length 63");
   CheckPinByGetAuthToken();
 
-  returned_status = AttemptChangePin(too_short_padded_pin);
+  returned_status = command_state_->AttemptChangePin(too_short_padded_pin);
   device_tracker_->CheckAndReport(Status::kErrPinPolicyViolation,
                                   returned_status,
                                   "reject to change to a PIN of length < 4");
   CheckPinByGetAuthToken();
   if (returned_status == Status::kErrNone) {
-    Reset();
+    command_state_->Reset();
   }
 
-  returned_status = AttemptChangePin(too_long_padded_pin);
+  returned_status = command_state_->AttemptChangePin(too_long_padded_pin);
   device_tracker_->CheckAndReport(Status::kErrPinPolicyViolation,
                                   returned_status,
                                   "reject to change to a PIN of length > 63");
   CheckPinByGetAuthToken();
   if (returned_status == Status::kErrNone) {
-    Reset();
+    command_state_->Reset();
   }
 
   // Again only testing maximum, not minimum PIN length.
-  ChangePin(maximum_pin_utf8);
+  device_tracker_->CheckAndReport(Status::kErrNone,
+                                  command_state_->ChangePin(maximum_pin_utf8),
+                                  "change to PIN of length 63");
   CheckPinByGetAuthToken();
 }
 
@@ -153,7 +157,7 @@ void TestSeries::ClientPinRequirements2Point1Test() {
   if (!IsFido2Point1Complicant()) {
     return;
   }
-  Reset();
+  command_state_->Reset();
   Status returned_status;
 
   cbor::Value::BinaryValue valid_pin_utf8 = {0x31, 0x32, 0x33, 0x34};
@@ -161,38 +165,38 @@ void TestSeries::ClientPinRequirements2Point1Test() {
   for (size_t i = 0; i < valid_pin_utf8.size(); ++i) {
     too_short_padding[i] = valid_pin_utf8[i];
   }
-  returned_status = AttemptSetPin(too_short_padding);
+  returned_status = command_state_->AttemptSetPin(too_short_padding);
   device_tracker_->CheckAndReport(Status::kErrPinPolicyViolation,
                                   returned_status,
                                   "reject to set a PIN padding of length 32");
   CheckPinAbsenceByMakeCredential();
   if (returned_status == Status::kErrNone) {
-    Reset();
+    command_state_->Reset();
   }
 
   cbor::Value::BinaryValue too_long_padding = cbor::Value::BinaryValue(128);
   for (size_t i = 0; i < valid_pin_utf8.size(); ++i) {
     too_long_padding[i] = valid_pin_utf8[i];
   }
-  returned_status = AttemptSetPin(too_long_padding);
+  returned_status = command_state_->AttemptSetPin(too_long_padding);
   device_tracker_->CheckAndReport(Status::kErrPinPolicyViolation,
                                   returned_status,
                                   "reject to set a PIN padding of length 128");
   CheckPinAbsenceByMakeCredential();
   if (returned_status == Status::kErrNone) {
-    Reset();
+    command_state_->Reset();
   }
 
-  returned_status = AttemptChangePin(too_short_padding);
+  returned_status = command_state_->AttemptChangePin(too_short_padding);
   device_tracker_->CheckAndReport(
       Status::kErrPinPolicyViolation, returned_status,
       "reject to change to a PIN padding of length 32");
   CheckPinByGetAuthToken();
   if (returned_status == Status::kErrNone) {
-    Reset();
+    command_state_->Reset();
   }
 
-  returned_status = AttemptChangePin(too_long_padding);
+  returned_status = command_state_->AttemptChangePin(too_long_padding);
   device_tracker_->CheckAndReport(
       Status::kErrPinPolicyViolation, returned_status,
       "reject to change to a PIN padding of length 128");
@@ -201,7 +205,7 @@ void TestSeries::ClientPinRequirements2Point1Test() {
 
 void TestSeries::ClientPinRetriesTest() {
   Status returned_status;
-  Reset();
+  command_state_->Reset();
 
   int initial_counter = GetPinRetries();
   device_tracker_->CheckAndReport(
@@ -212,14 +216,16 @@ void TestSeries::ClientPinRetriesTest() {
       GetPinRetries() == initial_counter,
       "PIN retries changed between subsequent calls");
 
-  returned_status = AttemptGetAuthToken(bad_pin_);
+  returned_status = command_state_->AttemptGetAuthToken(bad_pin_);
   device_tracker_->CheckAndReport(Status::kErrPinInvalid, returned_status,
                                   "reject wrong PIN");
   device_tracker_->CheckAndReport(
       GetPinRetries() == initial_counter - 1,
       "PIN retries decrement after a failed attempt");
 
-  GetAuthToken();
+  test_helpers::AssertCondition(
+      command_state_->GetAuthToken() == Status::kErrNone,
+      "get auth token for further tests");
   device_tracker_->CheckAndReport(
       GetPinRetries() == initial_counter,
       "PIN retries reset on entering the correct PIN");
@@ -227,25 +233,27 @@ void TestSeries::ClientPinRetriesTest() {
   constexpr int kWrongPinsBeforePowerCycle = 3;
   if (initial_counter > kWrongPinsBeforePowerCycle) {
     for (int i = 0; i < kWrongPinsBeforePowerCycle - 1; ++i) {
-      returned_status = AttemptGetAuthToken(bad_pin_);
+      returned_status = command_state_->AttemptGetAuthToken(bad_pin_);
       device_tracker_->CheckAndReport(Status::kErrPinInvalid, returned_status,
                                       "reject wrong PIN");
     }
-    returned_status = AttemptGetAuthToken(bad_pin_);
+    returned_status = command_state_->AttemptGetAuthToken(bad_pin_);
     device_tracker_->CheckAndReport(Status::kErrPinAuthBlocked, returned_status,
                                     "reject PIN before power cycle");
     device_tracker_->CheckAndReport(
         GetPinRetries() == initial_counter - kWrongPinsBeforePowerCycle,
         "PIN retry counter decremented until blocked");
-    returned_status = AttemptGetAuthToken(bad_pin_);
+    returned_status = command_state_->AttemptGetAuthToken(bad_pin_);
 
     device_tracker_->CheckAndReport(Status::kErrPinAuthBlocked, returned_status,
                                     "reject PIN before power cycle");
     device_tracker_->CheckAndReport(
         GetPinRetries() == initial_counter - kWrongPinsBeforePowerCycle,
         "PIN retry counter does not decrement in a blocked operation");
-    PromptReplugAndInit();
-    GetAuthToken();
+    command_state_->PromptReplugAndInit();
+    test_helpers::AssertCondition(
+        command_state_->GetAuthToken() == Status::kErrNone,
+        "get auth token for further tests");
     device_tracker_->CheckAndReport(
         GetPinRetries() == initial_counter,
         "PIN retries reset on entering the correct PIN");
@@ -259,40 +267,40 @@ void TestSeries::ClientPinRetriesTest() {
 
   // The next test checks whether the authenticator resets his own key agreement
   // key by reusing the old key material and see if it still works.
-  returned_status = AttemptGetAuthToken(bad_pin_, false);
+  returned_status = command_state_->AttemptGetAuthToken(bad_pin_, false);
   device_tracker_->CheckAndReport(Status::kErrPinInvalid, returned_status,
                                   "reject wrong PIN");
-  returned_status = AttemptGetAuthToken(pin_utf8_);
+  returned_status = command_state_->AttemptGetAuthToken();
   device_tracker_->CheckAndReport(
       Status::kErrPinInvalid, returned_status,
       "reject even the correct PIN if shared secrets do not match");
-  PromptReplugAndInit();
+  command_state_->PromptReplugAndInit();
 
   int remaining_retries = GetPinRetries();
   for (int i = 0; i < remaining_retries - 1; ++i) {
-    returned_status = AttemptGetAuthToken(bad_pin_);
+    returned_status = command_state_->AttemptGetAuthToken(bad_pin_);
     if (i % 3 != 2) {
       device_tracker_->CheckAndReport(Status::kErrPinInvalid, returned_status,
                                       "reject wrong PIN");
     } else {
       device_tracker_->CheckAndReport(Status::kErrPinAuthBlocked,
                                       returned_status, "reject wrong PIN");
-      PromptReplugAndInit();
+      command_state_->PromptReplugAndInit();
     }
   }
   device_tracker_->CheckAndReport(GetPinRetries() == 1,
                                   "PIN retry counter was reduced to 1");
-  returned_status = AttemptGetAuthToken(bad_pin_);
+  returned_status = command_state_->AttemptGetAuthToken(bad_pin_);
   device_tracker_->CheckAndReport(Status::kErrPinBlocked, returned_status,
                                   "block PIN retries if the counter gets to 0");
   device_tracker_->CheckAndReport(GetPinRetries() == 0,
                                   "PIN retry counter was reduced to 0");
-  returned_status = AttemptGetAuthToken(pin_utf8_);
+  returned_status = command_state_->AttemptGetAuthToken();
   device_tracker_->CheckAndReport(
       Status::kErrPinBlocked, returned_status,
       "reject even the correct PIN if the retry counter is 0");
 
-  Reset();
+  command_state_->Reset();
   // TODO(kaczmarczyck) check optional powerCycleState
 }
 

--- a/src/tests/test_general.cc
+++ b/src/tests/test_general.cc
@@ -89,7 +89,7 @@ void TestSeries::PersistenceTest() {
   MakeTestCredential(rp_id, true);
   cbor::Value credential_response = MakeTestCredential(rp_id, false);
 
-  PromptReplugAndInit();
+  command_state_->PromptReplugAndInit();
 
   GetAssertionCborBuilder persistence_get_assertion_builder;
   persistence_get_assertion_builder.AddDefaultsForRequiredFields(rp_id);
@@ -106,16 +106,17 @@ void TestSeries::PersistenceTest() {
   device_tracker_->CheckAndReport(response,
                                   "non-residential key persists after replug");
 
-  SetPin();
-  AttemptGetAuthToken(bad_pin_);
+  test_helpers::AssertCondition(command_state_->SetPin() == Status::kErrNone,
+                                "set pin for further tests");
+  command_state_->AttemptGetAuthToken(bad_pin_);
   int reduced_counter = GetPinRetries();
 
-  PromptReplugAndInit();
+  command_state_->PromptReplugAndInit();
 
   device_tracker_->CheckAndReport(GetPinRetries() == reduced_counter,
                                   "PIN retries persist after replug");
 
-  Reset();
+  command_state_->Reset();
 }
 
 }  // namespace fido2_tests

--- a/src/tests/test_get_assertion.cc
+++ b/src/tests/test_get_assertion.cc
@@ -162,8 +162,11 @@ void TestSeries::GetAssertionOptionsTest() {
   options_builder.SetUserVerificationOptions(true);
   if (device_tracker_->HasOption("clientPin")) {
     if (!device_tracker_->HasOption("uv")) {
-      GetAuthToken();
-      options_builder.SetDefaultPinUvAuthParam(auth_token_);
+      test_helpers::AssertCondition(
+          command_state_->GetAuthToken() == Status::kErrNone,
+          "get auth token for further tests");
+      options_builder.SetDefaultPinUvAuthParam(
+          command_state_->GetCurrentAuthToken());
       options_builder.SetDefaultPinUvAuthProtocol();
     }
     response = fido2_commands::GetAssertionPositiveTest(
@@ -172,7 +175,7 @@ void TestSeries::GetAssertionOptionsTest() {
         response, "recognize user verification option (true)");
     options_builder.RemoveMapEntry(GetAssertionParameters::kPinUvAuthParam);
     options_builder.RemoveMapEntry(GetAssertionParameters::kPinUvAuthProtocol);
-    Reset();
+    command_state_->Reset();
     MakeTestCredential(rp_id, true);
   } else {
     returned_status = fido2_commands::GetAssertionNegativeTest(
@@ -273,10 +276,13 @@ void TestSeries::GetAssertionPinAuthTest() {
   device_tracker_->CheckAndReport(Status::kErrPinNotSet, returned_status,
                                   "pin not set yet");
 
-  GetAuthToken();
+  test_helpers::AssertCondition(
+      command_state_->GetAuthToken() == Status::kErrNone,
+      "get auth token for further tests");
   // Sets a PIN if necessary. From here on, the PIN is set on the authenticator.
 
-  pin_auth_builder.SetDefaultPinUvAuthParam(auth_token_);
+  pin_auth_builder.SetDefaultPinUvAuthParam(
+      command_state_->GetCurrentAuthToken());
   response = fido2_commands::GetAssertionPositiveTest(
       device_, device_tracker_, pin_auth_builder.GetCbor());
   device_tracker_->CheckAndReport(response, "get assertion using PIN token");
@@ -306,14 +312,15 @@ void TestSeries::GetAssertionPinAuthTest() {
   device_tracker_->CheckAndReport(
       response, "get assertion with a PIN set, but without a token");
 
-  no_pin_auth_builder.SetDefaultPinUvAuthParam(auth_token_);
+  no_pin_auth_builder.SetDefaultPinUvAuthParam(
+      command_state_->GetCurrentAuthToken());
   returned_status = fido2_commands::GetAssertionNegativeTest(
       device_, no_pin_auth_builder.GetCbor(), false);
   device_tracker_->CheckAndReport(
       Status::kErrMissingParameter, returned_status,
       "PIN protocol not given, but PIN auth param is");
 
-  Reset();
+  command_state_->Reset();
 }
 
 void TestSeries::GetAssertionPhysicalPresenceTest() {

--- a/src/tests/test_series.cc
+++ b/src/tests/test_series.cc
@@ -29,8 +29,6 @@
 
 namespace fido2_tests {
 namespace {
-constexpr size_t kPinByteLength = 64;
-
 std::string CborTypeToString(cbor::Value::Type cbor_type) {
   switch (cbor_type) {
     case cbor::Value::Type::UNSIGNED:
@@ -138,9 +136,11 @@ void PrintNoTouchPrompt() {
 
 }  // namespace test_helpers
 
-TestSeries::TestSeries(DeviceInterface* device, DeviceTracker* device_tracker)
+TestSeries::TestSeries(DeviceInterface* device, DeviceTracker* device_tracker,
+                       CommandState* command_state)
     : device_(device),
       device_tracker_(device_tracker),
+      command_state_(command_state),
       cose_key_example_(crypto_utility::GenerateExampleEcdhCoseKey()),
       bad_pin_({0x66, 0x61, 0x6B, 0x65}) {
   cbor::Value::ArrayValue array_example;
@@ -157,23 +157,6 @@ TestSeries::TestSeries(DeviceInterface* device, DeviceTracker* device_tracker)
   // The TAG type is not supported, skipping it.
   type_examples_[cbor::Value::Type::SIMPLE_VALUE] =
       cbor::Value(cbor::Value::SimpleValue::TRUE_VALUE);
-
-  map_key_examples_[cbor::Value::Type::UNSIGNED] = cbor::Value(42);
-  map_key_examples_[cbor::Value::Type::NEGATIVE] = cbor::Value(-42);
-  map_key_examples_[cbor::Value::Type::BYTE_STRING] =
-      cbor::Value(cbor::Value::BinaryValue({0x42}));
-  map_key_examples_[cbor::Value::Type::STRING] = cbor::Value("42");
-}
-
-void TestSeries::PromptReplugAndInit() {
-  std::cout << "Please replug the device, then hit enter." << std::endl;
-  std::cin.ignore();
-  CHECK(fido2_tests::Status::kErrNone == device_->Init())
-      << "CTAPHID initialization failed";
-
-  platform_cose_key_ = cbor::Value::MapValue();
-  shared_secret_ = cbor::Value::BinaryValue();
-  auth_token_ = cbor::Value::BinaryValue();
 }
 
 bool TestSeries::IsFido2Point1Complicant() {
@@ -182,17 +165,8 @@ bool TestSeries::IsFido2Point1Complicant() {
 
 cbor::Value TestSeries::MakeTestCredential(const std::string& rp_id,
                                            bool use_residential_key) {
-  MakeCredentialCborBuilder test_builder;
-  test_builder.AddDefaultsForRequiredFields(rp_id);
-  test_builder.SetResidentialKeyOptions(use_residential_key);
-  if (!auth_token_.empty()) {
-    test_builder.SetDefaultPinUvAuthParam(auth_token_);
-    test_builder.SetDefaultPinUvAuthProtocol();
-  }
-
   absl::variant<cbor::Value, Status> response =
-      fido2_commands::MakeCredentialPositiveTest(device_, device_tracker_,
-                                                 test_builder.GetCbor());
+      command_state_->MakeTestCredential(rp_id, use_residential_key);
   test_helpers::AssertResponse(response, "make credential for further tests");
   return std::move(absl::get<cbor::Value>(response));
 }
@@ -383,181 +357,10 @@ int TestSeries::GetPinRetries() {
   return test_helpers::ExtractPinRetries(absl::get<cbor::Value>(response));
 }
 
-void TestSeries::ComputeSharedSecret() {
-  AuthenticatorClientPinCborBuilder key_agreement_builder;
-  key_agreement_builder.AddDefaultsForGetKeyAgreement();
-  absl::variant<cbor::Value, Status> key_response =
-      fido2_commands::AuthenticatorClientPinPositiveTest(
-          device_, device_tracker_, key_agreement_builder.GetCbor());
-  device_tracker_->CheckAndReport(key_response, "performing key agreement");
-  if (absl::holds_alternative<Status>(key_response)) {
-    std::cout << "Since key agreement failed, the next tests might be affected."
-              << std::endl;
-    return;
-  }
-
-  const auto& key_agreement_map = absl::get<cbor::Value>(key_response).GetMap();
-  auto map_iter = key_agreement_map.find(cbor::Value(1));
-  shared_secret_ = crypto_utility::CompleteEcdhHandshake(
-      map_iter->second.GetMap(), &platform_cose_key_);
-}
-
-void TestSeries::SetPin(const cbor::Value::BinaryValue& new_pin_utf8) {
-  if (platform_cose_key_.empty() || shared_secret_.empty()) {
-    ComputeSharedSecret();
-  }
-  if (!pin_utf8_.empty()) {
-    return;
-  }
-  CHECK(new_pin_utf8.size() >= 4 && new_pin_utf8.size() <= 63)
-      << "PIN requirements not fulfilled - TEST SUITE BUG";
-  CHECK(new_pin_utf8 != bad_pin_)
-      << "new PIN must be different from the bad example PIN - TEST SUITE BUG";
-
-  cbor::Value::BinaryValue new_padded_pin(kPinByteLength, 0);
-  std::copy(new_pin_utf8.begin(), new_pin_utf8.end(), new_padded_pin.begin());
-  cbor::Value::BinaryValue new_pin_enc =
-      crypto_utility::Aes256CbcEncrypt(shared_secret_, new_padded_pin);
-  cbor::Value::BinaryValue pin_auth =
-      crypto_utility::LeftHmacSha256(shared_secret_, new_pin_enc);
-
-  AuthenticatorClientPinCborBuilder set_pin_builder;
-  set_pin_builder.AddDefaultsForSetPin(platform_cose_key_, pin_auth,
-                                       new_pin_enc);
-  absl::variant<cbor::Value, Status> set_pin_response =
-      fido2_commands::AuthenticatorClientPinPositiveTest(
-          device_, device_tracker_, set_pin_builder.GetCbor());
-  test_helpers::AssertResponse(set_pin_response, "set PIN");
-  pin_utf8_ = new_pin_utf8;
-  std::cout << "The new PIN is ";
-  test_helpers::PrintByteVector(new_pin_utf8);
-}
-
-Status TestSeries::AttemptSetPin(
-    const cbor::Value::BinaryValue& new_padded_pin) {
-  if (platform_cose_key_.empty() || shared_secret_.empty()) {
-    ComputeSharedSecret();
-  }
-
-  cbor::Value::BinaryValue new_pin_enc =
-      crypto_utility::Aes256CbcEncrypt(shared_secret_, new_padded_pin);
-  cbor::Value::BinaryValue pin_auth =
-      crypto_utility::LeftHmacSha256(shared_secret_, new_pin_enc);
-
-  AuthenticatorClientPinCborBuilder set_pin_builder;
-  set_pin_builder.AddDefaultsForSetPin(platform_cose_key_, pin_auth,
-                                       new_pin_enc);
-  return fido2_commands::AuthenticatorClientPinNegativeTest(
-      device_, set_pin_builder.GetCbor(), false);
-}
-
-void TestSeries::ChangePin(const cbor::Value::BinaryValue& new_pin_utf8) {
-  SetPin();
-  CHECK(new_pin_utf8.size() >= 4 && new_pin_utf8.size() <= 63)
-      << "PIN requirements not fulfilled - TEST SUITE BUG";
-  CHECK(new_pin_utf8 != bad_pin_)
-      << "new PIN must be different from the bad example PIN - TEST SUITE BUG";
-
-  cbor::Value::BinaryValue new_padded_pin(kPinByteLength, 0);
-  std::copy(new_pin_utf8.begin(), new_pin_utf8.end(), new_padded_pin.begin());
-  cbor::Value::BinaryValue pin_hash_enc = crypto_utility::Aes256CbcEncrypt(
-      shared_secret_, crypto_utility::LeftSha256Hash(pin_utf8_));
-  cbor::Value::BinaryValue new_pin_enc =
-      crypto_utility::Aes256CbcEncrypt(shared_secret_, new_padded_pin);
-  cbor::Value::BinaryValue auth_data(new_pin_enc);
-  auth_data.insert(auth_data.end(), pin_hash_enc.begin(), pin_hash_enc.end());
-  cbor::Value::BinaryValue pin_auth =
-      crypto_utility::LeftHmacSha256(shared_secret_, auth_data);
-
-  AuthenticatorClientPinCborBuilder change_pin_builder;
-  change_pin_builder.AddDefaultsForChangePin(platform_cose_key_, pin_auth,
-                                             new_pin_enc, pin_hash_enc);
-  absl::variant<cbor::Value, Status> change_pin_response =
-      fido2_commands::AuthenticatorClientPinPositiveTest(
-          device_, device_tracker_, change_pin_builder.GetCbor());
-  test_helpers::AssertResponse(change_pin_response, "change PIN");
-  pin_utf8_ = new_pin_utf8;
-  std::cout << "The changed PIN is ";
-  test_helpers::PrintByteVector(new_pin_utf8);
-}
-
-Status TestSeries::AttemptChangePin(
-    const cbor::Value::BinaryValue& new_padded_pin) {
-  SetPin();
-
-  cbor::Value::BinaryValue pin_hash_enc = crypto_utility::Aes256CbcEncrypt(
-      shared_secret_, crypto_utility::LeftSha256Hash(pin_utf8_));
-  cbor::Value::BinaryValue new_pin_enc =
-      crypto_utility::Aes256CbcEncrypt(shared_secret_, new_padded_pin);
-  cbor::Value::BinaryValue auth_data(new_pin_enc);
-  auth_data.insert(auth_data.end(), pin_hash_enc.begin(), pin_hash_enc.end());
-  cbor::Value::BinaryValue pin_auth =
-      crypto_utility::LeftHmacSha256(shared_secret_, auth_data);
-
-  AuthenticatorClientPinCborBuilder change_pin_builder;
-  change_pin_builder.AddDefaultsForChangePin(platform_cose_key_, pin_auth,
-                                             new_pin_enc, pin_hash_enc);
-  Status returned_status = fido2_commands::AuthenticatorClientPinNegativeTest(
-      device_, change_pin_builder.GetCbor(), false);
-  // Since failed PIN checks reset the key agreement, keep the state consistent.
-  ComputeSharedSecret();
-  return returned_status;
-}
-
-void TestSeries::GetAuthToken() {
-  SetPin();
-
-  AuthenticatorClientPinCborBuilder pin_token_builder;
-  cbor::Value::BinaryValue pin_hash_enc = crypto_utility::Aes256CbcEncrypt(
-      shared_secret_, crypto_utility::LeftSha256Hash(pin_utf8_));
-  pin_token_builder.AddDefaultsForGetPinUvAuthTokenUsingPin(platform_cose_key_,
-                                                            pin_hash_enc);
-  absl::variant<cbor::Value, Status> pin_token_response =
-      fido2_commands::AuthenticatorClientPinPositiveTest(
-          device_, device_tracker_, pin_token_builder.GetCbor());
-  test_helpers::AssertResponse(pin_token_response, "getting PIN auth token");
-
-  const auto& pin_token_map =
-      absl::get<cbor::Value>(pin_token_response).GetMap();
-  auto map_iter = pin_token_map.find(cbor::Value(2));
-  cbor::Value::BinaryValue encrypted_token = map_iter->second.GetBytestring();
-  auth_token_ =
-      crypto_utility::Aes256CbcDecrypt(shared_secret_, encrypted_token);
-}
-
-Status TestSeries::AttemptGetAuthToken(const cbor::Value::BinaryValue& pin_utf8,
-                                       bool redo_key_agreement) {
-  SetPin();
-
-  AuthenticatorClientPinCborBuilder pin_token_builder;
-  cbor::Value::BinaryValue pin_hash_enc = crypto_utility::Aes256CbcEncrypt(
-      shared_secret_, crypto_utility::LeftSha256Hash(pin_utf8));
-  pin_token_builder.AddDefaultsForGetPinUvAuthTokenUsingPin(platform_cose_key_,
-                                                            pin_hash_enc);
-  Status returned_status = fido2_commands::AuthenticatorClientPinNegativeTest(
-      device_, pin_token_builder.GetCbor(), false);
-  if (redo_key_agreement) {
-    // Since failed PIN checks reset the key agreement, keep the state
-    // consistent.
-    ComputeSharedSecret();
-  }
-  return returned_status;
-}
-
 void TestSeries::CheckPinByGetAuthToken() {
-  AuthenticatorClientPinCborBuilder pin_token_builder;
-  cbor::Value::BinaryValue pin_hash_enc = crypto_utility::Aes256CbcEncrypt(
-      shared_secret_, crypto_utility::LeftSha256Hash(pin_utf8_));
-  pin_token_builder.AddDefaultsForGetPinUvAuthTokenUsingPin(platform_cose_key_,
-                                                            pin_hash_enc);
-  absl::variant<cbor::Value, Status> pin_token_response =
-      fido2_commands::AuthenticatorClientPinPositiveTest(
-          device_, device_tracker_, pin_token_builder.GetCbor());
-  device_tracker_->CheckAndReport(pin_token_response,
-                                  "PIN was usable for getting an auth token");
-
-  // Since failed PIN checks reset the key agreement, keep the state consistent.
-  ComputeSharedSecret();
+  device_tracker_->CheckAndReport(
+      /*Status::kErrNone, */ command_state_->GetAuthToken(false),
+      "PIN was usable for getting an auth token");
 }
 
 void TestSeries::CheckPinAbsenceByMakeCredential() {

--- a/src/tests/test_series.h
+++ b/src/tests/test_series.h
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TEST_SERIES_H_
-#define TEST_SERIES_H_
+#ifndef TESTS_TEST_SERIES_H_
+#define TESTS_TEST_SERIES_H_
 
 #include <cstdio>
 
 #include "absl/types/variant.h"
 #include "src/cbor_builders.h"
+#include "src/command_state.h"
 #include "src/device_interface.h"
 #include "src/device_tracker.h"
 #include "third_party/chromium_components_cbor/values.h"
@@ -40,7 +41,8 @@ class TestSeries {
  public:
   // The ownership for device and device_tracker stays with the caller and must
   // outlive the TestSeries instance.
-  TestSeries(DeviceInterface* device, DeviceTracker* device_tracker);
+  TestSeries(DeviceInterface* device, DeviceTracker* device_tracker,
+             CommandState* command_state);
 
   // Tests for MakeCredential.
 
@@ -153,10 +155,6 @@ class TestSeries {
   void PersistenceTest();
 
  private:
-  // Prompts the user to replug the device which is required before operations
-  // that need a power cycle (i.e. resetting). The Init will then handle device
-  // initilalization, regardless of the current state of the device.
-  void PromptReplugAndInit();
   // TODO(#16) replace version string with FIDO_2_1 when specification is final
   bool IsFido2Point1Complicant();
   // Makes a credential for all tests that require one, for example assertions.
@@ -207,37 +205,6 @@ class TestSeries {
 
   // Gets and checks the PIN retry counter response from the authenticator.
   int GetPinRetries();
-  // Compute the shared secret between authenticator and platform. Sets the
-  // argument platform_cose_key to the EC key used during the transaction.
-  void ComputeSharedSecret();
-  // Sets the PIN to the value specified in new_pin_utf8. Performs key agreement
-  // if not already done. Safe to call multiple times, and only talks to the
-  // authenticator if there is no PIN already. Defaults to 1234 if nothing else
-  // is set. Fails if the PIN requirements are not satisfied.
-  void SetPin(const cbor::Value::BinaryValue& new_pin_utf8 = {0x31, 0x32, 0x33,
-                                                              0x34});
-  // Calls the SetPin command with the given padded PIN. Fails if the length is
-  // not a multiple of the AES block size. Returns the command's status code.
-  // Performs key agreement if not already done.
-  Status AttemptSetPin(const cbor::Value::BinaryValue& new_padded_pin);
-  // Changes the current PIN to new_pin_utf8. Fails if the PIN requirements are
-  // not satisfied. Creates a PIN if not already done.
-  void ChangePin(const cbor::Value::BinaryValue& new_pin_utf8);
-  // Calls the ChangePin command with the given padded PIN, using the currently
-  // set PIN. Fails if the length is not a multiple of the AES block size.
-  // Returns the command's status code. Creates a PIN if not already done.
-  Status AttemptChangePin(const cbor::Value::BinaryValue& new_padded_pin);
-  // Returns a PIN Auth token valid for this power cycle from the authenticator.
-  // Sets the PIN to 1234 if no PIN exists.
-  void GetAuthToken();
-  // Calls the GetAuthToken command with the given PIN. Creates a PIN if
-  // not already done. Returns the command's status code. If redo_key_agreement
-  // is true, it brings the shared_secret back to a valid state. This is
-  // necessary because authenticators reset the key agreement on failed PIN
-  // hash checks. Setting redo_key_agreement is only used for specific failure
-  // mode tests.
-  Status AttemptGetAuthToken(const cbor::Value::BinaryValue& pin_utf8,
-                             bool redo_key_agreement = true);
   // Checks if the PIN we currently assume is set works for getting an auth
   // token. This way, we don't have to trust only the returned status code
   // after a SetPin or ChangePin command. It does not actually return an auth
@@ -252,26 +219,13 @@ class TestSeries {
 
   DeviceInterface* device_;
   DeviceTracker* device_tracker_;
+  CommandState* command_state_;
   // These are arbitrary example values for each CBOR type.
   std::map<cbor::Value::Type, cbor::Value> type_examples_;
-  // This map is a subset of the type_examples_. Since CBOR implementations do
-  // not need to allow all CBOR types as map keys, testing on all of them for
-  // map keys might produce different error codes. Since we currently enforce
-  // a specific error code, use this subset of CBOR types for all tests on map
-  // keys. Allowed map keys might depend on the CBOR parser implementation.
-  // The specification only states: "Note that this rule allows maps that have
-  // keys of different types, even though that is probably a bad practice that
-  // could lead to errors in some canonicalization implementations."
-  std::map<cbor::Value::Type, cbor::Value> map_key_examples_;
   // This is an example of an EC cose key map for client PIN operations.
   cbor::Value::MapValue cose_key_example_;
   // This is an example PIN that should be different from the real PIN.
   const cbor::Value::BinaryValue bad_pin_;
-  // The PIN is persistent, the other state is kept for a power cycle.
-  cbor::Value::MapValue platform_cose_key_;
-  cbor::Value::BinaryValue shared_secret_;
-  cbor::Value::BinaryValue pin_utf8_;
-  cbor::Value::BinaryValue auth_token_;
 };
 
 namespace test_helpers {
@@ -298,4 +252,4 @@ void PrintNoTouchPrompt();
 
 }  // namespace fido2_tests
 
-#endif  // TEST_SERIES_H_
+#endif  // TESTS_TEST_SERIES_H_


### PR DESCRIPTION
This is the first PR for a series that will make tests more self-contained, or track where they are not. This first PR moves stateful code out of the `TestSeries` class.