### PR TITLE
removes all private members from the TestSeries class

### DIFF
--- a/src/fido2_conformance_main.cc
+++ b/src/fido2_conformance_main.cc
@@ -57,50 +57,72 @@ int main(int argc, char** argv) {
   // Resets and initializes.
   fido2_tests::CommandState command_state(device.get(), &tracker);
 
-  fido2_tests::TestSeries test_series =
-      fido2_tests::TestSeries(device.get(), &tracker, &command_state);
+  fido2_tests::TestSeries test_series = fido2_tests::TestSeries();
 
-  test_series.MakeCredentialBadParameterTypesTest();
-  test_series.MakeCredentialMissingParameterTest();
-  test_series.MakeCredentialRelyingPartyEntityTest();
-  test_series.MakeCredentialUserEntityTest();
-  test_series.MakeCredentialExcludeListCredentialDescriptorTest();
-  test_series.MakeCredentialExtensionsTest();
-  test_series.GetAssertionBadParameterTypesTest();
-  test_series.GetAssertionMissingParameterTest();
-  test_series.GetAssertionAllowListCredentialDescriptorTest();
-  test_series.GetAssertionExtensionsTest();
-  test_series.ClientPinGetPinRetriesTest();
-  test_series.ClientPinGetKeyAgreementTest();
-  test_series.ClientPinSetPinTest();
-  test_series.ClientPinChangePinTest();
-  test_series.ClientPinGetPinUvAuthTokenUsingPinTest();
-  test_series.ClientPinGetPinUvAuthTokenUsingUvTest();
-  test_series.ClientPinGetUVRetriesTest();
+  test_series.MakeCredentialBadParameterTypesTest(device.get(), &tracker,
+                                                  &command_state);
+  test_series.MakeCredentialMissingParameterTest(device.get(), &tracker,
+                                                 &command_state);
+  test_series.MakeCredentialRelyingPartyEntityTest(device.get(), &tracker,
+                                                   &command_state);
+  test_series.MakeCredentialUserEntityTest(device.get(), &tracker,
+                                           &command_state);
+  test_series.MakeCredentialExcludeListCredentialDescriptorTest(
+      device.get(), &tracker, &command_state);
+  test_series.MakeCredentialExtensionsTest(device.get(), &tracker,
+                                           &command_state);
+  test_series.GetAssertionBadParameterTypesTest(device.get(), &tracker,
+                                                &command_state);
+  test_series.GetAssertionMissingParameterTest(device.get(), &tracker,
+                                               &command_state);
+  test_series.GetAssertionAllowListCredentialDescriptorTest(
+      device.get(), &tracker, &command_state);
+  test_series.GetAssertionExtensionsTest(device.get(), &tracker,
+                                         &command_state);
+  test_series.ClientPinGetPinRetriesTest(device.get(), &tracker,
+                                         &command_state);
+  test_series.ClientPinGetKeyAgreementTest(device.get(), &tracker,
+                                           &command_state);
+  test_series.ClientPinSetPinTest(device.get(), &tracker, &command_state);
+  test_series.ClientPinChangePinTest(device.get(), &tracker, &command_state);
+  test_series.ClientPinGetPinUvAuthTokenUsingPinTest(device.get(), &tracker,
+                                                     &command_state);
+  test_series.ClientPinGetPinUvAuthTokenUsingUvTest(device.get(), &tracker,
+                                                    &command_state);
+  test_series.ClientPinGetUVRetriesTest(device.get(), &tracker, &command_state);
 
-  test_series.ResetDeletionTest();
-  test_series.ResetPhysicalPresenceTest();
-  test_series.PersistenceTest();
+  test_series.ResetDeletionTest(device.get(), &tracker, &command_state);
+  test_series.ResetPhysicalPresenceTest(device.get(), &tracker, &command_state);
+  test_series.PersistenceTest(device.get(), &tracker, &command_state);
 
-  test_series.MakeCredentialExcludeListTest();
-  test_series.MakeCredentialCoseAlgorithmTest();
-  test_series.MakeCredentialOptionsTest();
-  test_series.MakeCredentialPinAuthTest();
-  test_series.MakeCredentialMultipleKeysTest(FLAGS_num_credentials);
-  test_series.MakeCredentialPhysicalPresenceTest();
-  test_series.MakeCredentialDisplayNameEncodingTest();
+  test_series.MakeCredentialExcludeListTest(device.get(), &tracker,
+                                            &command_state);
+  test_series.MakeCredentialCoseAlgorithmTest(device.get(), &tracker,
+                                              &command_state);
+  test_series.MakeCredentialOptionsTest(device.get(), &tracker, &command_state);
+  test_series.MakeCredentialPinAuthTest(device.get(), &tracker, &command_state);
+  test_series.MakeCredentialMultipleKeysTest(
+      device.get(), &tracker, &command_state, FLAGS_num_credentials);
+  test_series.MakeCredentialPhysicalPresenceTest(device.get(), &tracker,
+                                                 &command_state);
+  test_series.MakeCredentialDisplayNameEncodingTest(device.get(), &tracker,
+                                                    &command_state);
 
-  test_series.GetAssertionOptionsTest();
-  test_series.GetAssertionResidentialKeyTest();
-  test_series.GetAssertionPinAuthTest();
-  test_series.GetAssertionPhysicalPresenceTest();
+  test_series.GetAssertionOptionsTest(device.get(), &tracker, &command_state);
+  test_series.GetAssertionResidentialKeyTest(device.get(), &tracker,
+                                             &command_state);
+  test_series.GetAssertionPinAuthTest(device.get(), &tracker, &command_state);
+  test_series.GetAssertionPhysicalPresenceTest(device.get(), &tracker,
+                                               &command_state);
 
-  test_series.GetInfoTest();
+  test_series.GetInfoTest(device.get(), &tracker, &command_state);
 
-  test_series.ClientPinRequirementsTest();
-  test_series.ClientPinRequirements2Point1Test();
-  test_series.ClientPinRetriesTest();
-  test_series.MakeCredentialHmacSecretTest();
+  test_series.ClientPinRequirementsTest(device.get(), &tracker, &command_state);
+  test_series.ClientPinRequirements2Point1Test(device.get(), &tracker,
+                                               &command_state);
+  test_series.ClientPinRetriesTest(device.get(), &tracker, &command_state);
+  test_series.MakeCredentialHmacSecretTest(device.get(), &tracker,
+                                           &command_state);
 
   std::cout << "\nRESULTS" << std::endl;
   tracker.ReportFindings();

--- a/src/tests/test_client_pin.cc
+++ b/src/tests/test_client_pin.cc
@@ -35,67 +35,97 @@ static const auto* const kCoseKeyExample =
 
 }  // namespace
 
-void TestSeries::ClientPinGetPinRetriesTest() {
+void TestSeries::ClientPinGetPinRetriesTest(DeviceInterface* device,
+                                            DeviceTracker* device_tracker,
+                                            CommandState* command_state) {
   AuthenticatorClientPinCborBuilder pin1_builder;
   pin1_builder.AddDefaultsForGetPinRetries();
-  TestBadParameterTypes(Command::kAuthenticatorClientPIN, &pin1_builder);
-  TestMissingParameters(Command::kAuthenticatorClientPIN, &pin1_builder);
+  test_helpers::TestBadParameterTypes(
+      device, device_tracker, Command::kAuthenticatorClientPIN, &pin1_builder);
+  test_helpers::TestMissingParameters(
+      device, device_tracker, Command::kAuthenticatorClientPIN, &pin1_builder);
 }
 
-void TestSeries::ClientPinGetKeyAgreementTest() {
+void TestSeries::ClientPinGetKeyAgreementTest(DeviceInterface* device,
+                                              DeviceTracker* device_tracker,
+                                              CommandState* command_state) {
   // crypto_utility enforces that the COSE key map only has the correct entries.
   AuthenticatorClientPinCborBuilder pin2_builder;
   pin2_builder.AddDefaultsForGetKeyAgreement();
-  TestBadParameterTypes(Command::kAuthenticatorClientPIN, &pin2_builder);
-  TestMissingParameters(Command::kAuthenticatorClientPIN, &pin2_builder);
+  test_helpers::TestBadParameterTypes(
+      device, device_tracker, Command::kAuthenticatorClientPIN, &pin2_builder);
+  test_helpers::TestMissingParameters(
+      device, device_tracker, Command::kAuthenticatorClientPIN, &pin2_builder);
 }
 
-void TestSeries::ClientPinSetPinTest() {
+void TestSeries::ClientPinSetPinTest(DeviceInterface* device,
+                                     DeviceTracker* device_tracker,
+                                     CommandState* command_state) {
   AuthenticatorClientPinCborBuilder pin3_builder;
   pin3_builder.AddDefaultsForSetPin(
       *kCoseKeyExample, cbor::Value::BinaryValue(), cbor::Value::BinaryValue());
-  TestBadParameterTypes(Command::kAuthenticatorClientPIN, &pin3_builder);
-  TestMissingParameters(Command::kAuthenticatorClientPIN, &pin3_builder);
+  test_helpers::TestBadParameterTypes(
+      device, device_tracker, Command::kAuthenticatorClientPIN, &pin3_builder);
+  test_helpers::TestMissingParameters(
+      device, device_tracker, Command::kAuthenticatorClientPIN, &pin3_builder);
 }
 
-void TestSeries::ClientPinChangePinTest() {
+void TestSeries::ClientPinChangePinTest(DeviceInterface* device,
+                                        DeviceTracker* device_tracker,
+                                        CommandState* command_state) {
   AuthenticatorClientPinCborBuilder pin4_builder;
   pin4_builder.AddDefaultsForChangePin(
       *kCoseKeyExample, cbor::Value::BinaryValue(), cbor::Value::BinaryValue(),
       cbor::Value::BinaryValue());
-  TestBadParameterTypes(Command::kAuthenticatorClientPIN, &pin4_builder);
-  TestMissingParameters(Command::kAuthenticatorClientPIN, &pin4_builder);
+  test_helpers::TestBadParameterTypes(
+      device, device_tracker, Command::kAuthenticatorClientPIN, &pin4_builder);
+  test_helpers::TestMissingParameters(
+      device, device_tracker, Command::kAuthenticatorClientPIN, &pin4_builder);
 }
 
-void TestSeries::ClientPinGetPinUvAuthTokenUsingPinTest() {
+void TestSeries::ClientPinGetPinUvAuthTokenUsingPinTest(
+    DeviceInterface* device, DeviceTracker* device_tracker,
+    CommandState* command_state) {
   AuthenticatorClientPinCborBuilder pin5_builder;
   pin5_builder.AddDefaultsForGetPinUvAuthTokenUsingPin(
       *kCoseKeyExample, cbor::Value::BinaryValue());
-  TestBadParameterTypes(Command::kAuthenticatorClientPIN, &pin5_builder);
-  TestMissingParameters(Command::kAuthenticatorClientPIN, &pin5_builder);
+  test_helpers::TestBadParameterTypes(
+      device, device_tracker, Command::kAuthenticatorClientPIN, &pin5_builder);
+  test_helpers::TestMissingParameters(
+      device, device_tracker, Command::kAuthenticatorClientPIN, &pin5_builder);
 }
 
-void TestSeries::ClientPinGetPinUvAuthTokenUsingUvTest() {
-  if (!IsFido2Point1Complicant()) {
+void TestSeries::ClientPinGetPinUvAuthTokenUsingUvTest(
+    DeviceInterface* device, DeviceTracker* device_tracker,
+    CommandState* command_state) {
+  if (!test_helpers::IsFido2Point1Complicant(device_tracker)) {
     return;
   }
   AuthenticatorClientPinCborBuilder pin6_builder;
   pin6_builder.AddDefaultsForGetPinUvAuthTokenUsingUv(*kCoseKeyExample);
-  TestBadParameterTypes(Command::kAuthenticatorClientPIN, &pin6_builder);
-  TestMissingParameters(Command::kAuthenticatorClientPIN, &pin6_builder);
+  test_helpers::TestBadParameterTypes(
+      device, device_tracker, Command::kAuthenticatorClientPIN, &pin6_builder);
+  test_helpers::TestMissingParameters(
+      device, device_tracker, Command::kAuthenticatorClientPIN, &pin6_builder);
 }
 
-void TestSeries::ClientPinGetUVRetriesTest() {
-  if (!IsFido2Point1Complicant()) {
+void TestSeries::ClientPinGetUVRetriesTest(DeviceInterface* device,
+                                           DeviceTracker* device_tracker,
+                                           CommandState* command_state) {
+  if (!test_helpers::IsFido2Point1Complicant(device_tracker)) {
     return;
   }
   AuthenticatorClientPinCborBuilder pin7_builder;
   pin7_builder.AddDefaultsForGetUvRetries();
-  TestBadParameterTypes(Command::kAuthenticatorClientPIN, &pin7_builder);
-  TestMissingParameters(Command::kAuthenticatorClientPIN, &pin7_builder);
+  test_helpers::TestBadParameterTypes(
+      device, device_tracker, Command::kAuthenticatorClientPIN, &pin7_builder);
+  test_helpers::TestMissingParameters(
+      device, device_tracker, Command::kAuthenticatorClientPIN, &pin7_builder);
 }
 
-void TestSeries::ClientPinRequirementsTest() {
+void TestSeries::ClientPinRequirementsTest(DeviceInterface* device,
+                                           DeviceTracker* device_tracker,
+                                           CommandState* command_state) {
   Status returned_status;
 
   cbor::Value::BinaryValue too_short_pin_utf8 = {0x31, 0x32, 0x33};
@@ -104,24 +134,24 @@ void TestSeries::ClientPinRequirementsTest() {
   for (size_t i = 0; i < too_short_pin_utf8.size(); ++i) {
     too_short_padded_pin[i] = too_short_pin_utf8[i];
   }
-  returned_status = command_state_->AttemptSetPin(too_short_padded_pin);
-  device_tracker_->CheckAndReport(Status::kErrPinPolicyViolation,
-                                  returned_status,
-                                  "reject to set a PIN of length < 4");
-  CheckPinAbsenceByMakeCredential();
+  returned_status = command_state->AttemptSetPin(too_short_padded_pin);
+  device_tracker->CheckAndReport(Status::kErrPinPolicyViolation,
+                                 returned_status,
+                                 "reject to set a PIN of length < 4");
+  test_helpers::CheckPinAbsenceByMakeCredential(device, device_tracker);
   if (returned_status == Status::kErrNone) {
-    command_state_->Reset();
+    command_state->Reset();
   }
 
   cbor::Value::BinaryValue too_long_padded_pin =
       cbor::Value::BinaryValue(64, 0x30);
-  returned_status = command_state_->AttemptSetPin(too_long_padded_pin);
-  device_tracker_->CheckAndReport(Status::kErrPinPolicyViolation,
-                                  returned_status,
-                                  "reject to set a PIN of length > 63");
-  CheckPinAbsenceByMakeCredential();
+  returned_status = command_state->AttemptSetPin(too_long_padded_pin);
+  device_tracker->CheckAndReport(Status::kErrPinPolicyViolation,
+                                 returned_status,
+                                 "reject to set a PIN of length > 63");
+  test_helpers::CheckPinAbsenceByMakeCredential(device, device_tracker);
   if (returned_status == Status::kErrNone) {
-    command_state_->Reset();
+    command_state->Reset();
   }
 
   // The minimum length is 4, but the authenticator can enforce more, so only
@@ -129,41 +159,43 @@ void TestSeries::ClientPinRequirementsTest() {
   // TODO(kaczmarczyck) use minimum PIN length from GetInfo
   cbor::Value::BinaryValue maximum_pin_utf8 =
       cbor::Value::BinaryValue(63, 0x30);
-  device_tracker_->CheckAndReport(Status::kErrNone,
-                                  command_state_->SetPin(maximum_pin_utf8),
-                                  "set PIN of length 63");
-  CheckPinByGetAuthToken();
+  device_tracker->CheckAndReport(Status::kErrNone,
+                                 command_state->SetPin(maximum_pin_utf8),
+                                 "set PIN of length 63");
+  test_helpers::CheckPinByGetAuthToken(device_tracker, command_state);
 
-  returned_status = command_state_->AttemptChangePin(too_short_padded_pin);
-  device_tracker_->CheckAndReport(Status::kErrPinPolicyViolation,
-                                  returned_status,
-                                  "reject to change to a PIN of length < 4");
-  CheckPinByGetAuthToken();
+  returned_status = command_state->AttemptChangePin(too_short_padded_pin);
+  device_tracker->CheckAndReport(Status::kErrPinPolicyViolation,
+                                 returned_status,
+                                 "reject to change to a PIN of length < 4");
+  test_helpers::CheckPinByGetAuthToken(device_tracker, command_state);
   if (returned_status == Status::kErrNone) {
-    command_state_->Reset();
+    command_state->Reset();
   }
 
-  returned_status = command_state_->AttemptChangePin(too_long_padded_pin);
-  device_tracker_->CheckAndReport(Status::kErrPinPolicyViolation,
-                                  returned_status,
-                                  "reject to change to a PIN of length > 63");
-  CheckPinByGetAuthToken();
+  returned_status = command_state->AttemptChangePin(too_long_padded_pin);
+  device_tracker->CheckAndReport(Status::kErrPinPolicyViolation,
+                                 returned_status,
+                                 "reject to change to a PIN of length > 63");
+  test_helpers::CheckPinByGetAuthToken(device_tracker, command_state);
   if (returned_status == Status::kErrNone) {
-    command_state_->Reset();
+    command_state->Reset();
   }
 
   // Again only testing maximum, not minimum PIN length.
-  device_tracker_->CheckAndReport(Status::kErrNone,
-                                  command_state_->ChangePin(maximum_pin_utf8),
-                                  "change to PIN of length 63");
-  CheckPinByGetAuthToken();
+  device_tracker->CheckAndReport(Status::kErrNone,
+                                 command_state->ChangePin(maximum_pin_utf8),
+                                 "change to PIN of length 63");
+  test_helpers::CheckPinByGetAuthToken(device_tracker, command_state);
 }
 
-void TestSeries::ClientPinRequirements2Point1Test() {
-  if (!IsFido2Point1Complicant()) {
+void TestSeries::ClientPinRequirements2Point1Test(DeviceInterface* device,
+                                                  DeviceTracker* device_tracker,
+                                                  CommandState* command_state) {
+  if (!test_helpers::IsFido2Point1Complicant(device_tracker)) {
     return;
   }
-  command_state_->Reset();
+  command_state->Reset();
   Status returned_status;
 
   cbor::Value::BinaryValue valid_pin_utf8 = {0x31, 0x32, 0x33, 0x34};
@@ -171,98 +203,103 @@ void TestSeries::ClientPinRequirements2Point1Test() {
   for (size_t i = 0; i < valid_pin_utf8.size(); ++i) {
     too_short_padding[i] = valid_pin_utf8[i];
   }
-  returned_status = command_state_->AttemptSetPin(too_short_padding);
-  device_tracker_->CheckAndReport(Status::kErrPinPolicyViolation,
-                                  returned_status,
-                                  "reject to set a PIN padding of length 32");
-  CheckPinAbsenceByMakeCredential();
+  returned_status = command_state->AttemptSetPin(too_short_padding);
+  device_tracker->CheckAndReport(Status::kErrPinPolicyViolation,
+                                 returned_status,
+                                 "reject to set a PIN padding of length 32");
+  test_helpers::CheckPinAbsenceByMakeCredential(device, device_tracker);
   if (returned_status == Status::kErrNone) {
-    command_state_->Reset();
+    command_state->Reset();
   }
 
   cbor::Value::BinaryValue too_long_padding = cbor::Value::BinaryValue(128);
   for (size_t i = 0; i < valid_pin_utf8.size(); ++i) {
     too_long_padding[i] = valid_pin_utf8[i];
   }
-  returned_status = command_state_->AttemptSetPin(too_long_padding);
-  device_tracker_->CheckAndReport(Status::kErrPinPolicyViolation,
-                                  returned_status,
-                                  "reject to set a PIN padding of length 128");
-  CheckPinAbsenceByMakeCredential();
+  returned_status = command_state->AttemptSetPin(too_long_padding);
+  device_tracker->CheckAndReport(Status::kErrPinPolicyViolation,
+                                 returned_status,
+                                 "reject to set a PIN padding of length 128");
+  test_helpers::CheckPinAbsenceByMakeCredential(device, device_tracker);
   if (returned_status == Status::kErrNone) {
-    command_state_->Reset();
+    command_state->Reset();
   }
 
-  returned_status = command_state_->AttemptChangePin(too_short_padding);
-  device_tracker_->CheckAndReport(
+  returned_status = command_state->AttemptChangePin(too_short_padding);
+  device_tracker->CheckAndReport(
       Status::kErrPinPolicyViolation, returned_status,
       "reject to change to a PIN padding of length 32");
-  CheckPinByGetAuthToken();
+  test_helpers::CheckPinByGetAuthToken(device_tracker, command_state);
   if (returned_status == Status::kErrNone) {
-    command_state_->Reset();
+    command_state->Reset();
   }
 
-  returned_status = command_state_->AttemptChangePin(too_long_padding);
-  device_tracker_->CheckAndReport(
+  returned_status = command_state->AttemptChangePin(too_long_padding);
+  device_tracker->CheckAndReport(
       Status::kErrPinPolicyViolation, returned_status,
       "reject to change to a PIN padding of length 128");
-  CheckPinByGetAuthToken();
+  test_helpers::CheckPinByGetAuthToken(device_tracker, command_state);
 }
 
-void TestSeries::ClientPinRetriesTest() {
+void TestSeries::ClientPinRetriesTest(DeviceInterface* device,
+                                      DeviceTracker* device_tracker,
+                                      CommandState* command_state) {
   Status returned_status;
-  command_state_->Reset();
+  command_state->Reset();
 
-  int initial_counter = GetPinRetries();
-  device_tracker_->CheckAndReport(
+  int initial_counter = test_helpers::GetPinRetries(device, device_tracker);
+  device_tracker->CheckAndReport(
       initial_counter <= 8, "maximum PIN retries holds the upper limit of 8");
-  device_tracker_->CheckAndReport(initial_counter > 0,
-                                  "maximum PIN retries is positive");
-  device_tracker_->CheckAndReport(
-      GetPinRetries() == initial_counter,
+  device_tracker->CheckAndReport(initial_counter > 0,
+                                 "maximum PIN retries is positive");
+  device_tracker->CheckAndReport(
+      test_helpers::GetPinRetries(device, device_tracker) == initial_counter,
       "PIN retries changed between subsequent calls");
 
-  returned_status = command_state_->AttemptGetAuthToken(test_helpers::BadPin());
-  device_tracker_->CheckAndReport(Status::kErrPinInvalid, returned_status,
-                                  "reject wrong PIN");
-  device_tracker_->CheckAndReport(
-      GetPinRetries() == initial_counter - 1,
+  returned_status = command_state->AttemptGetAuthToken(test_helpers::BadPin());
+  device_tracker->CheckAndReport(Status::kErrPinInvalid, returned_status,
+                                 "reject wrong PIN");
+  device_tracker->CheckAndReport(
+      test_helpers::GetPinRetries(device, device_tracker) ==
+          initial_counter - 1,
       "PIN retries decrement after a failed attempt");
 
-  device_tracker_->AssertStatus(command_state_->GetAuthToken(),
-                                "get auth token for further tests");
-  device_tracker_->CheckAndReport(
-      GetPinRetries() == initial_counter,
+  device_tracker->AssertStatus(command_state->GetAuthToken(),
+                               "get auth token for further tests");
+  device_tracker->CheckAndReport(
+      test_helpers::GetPinRetries(device, device_tracker) == initial_counter,
       "PIN retries reset on entering the correct PIN");
 
   constexpr int kWrongPinsBeforePowerCycle = 3;
   if (initial_counter > kWrongPinsBeforePowerCycle) {
     for (int i = 0; i < kWrongPinsBeforePowerCycle - 1; ++i) {
       returned_status =
-          command_state_->AttemptGetAuthToken(test_helpers::BadPin());
-      device_tracker_->CheckAndReport(Status::kErrPinInvalid, returned_status,
-                                      "reject wrong PIN");
+          command_state->AttemptGetAuthToken(test_helpers::BadPin());
+      device_tracker->CheckAndReport(Status::kErrPinInvalid, returned_status,
+                                     "reject wrong PIN");
     }
     returned_status =
-        command_state_->AttemptGetAuthToken(test_helpers::BadPin());
-    device_tracker_->CheckAndReport(Status::kErrPinAuthBlocked, returned_status,
-                                    "reject PIN before power cycle");
-    device_tracker_->CheckAndReport(
-        GetPinRetries() == initial_counter - kWrongPinsBeforePowerCycle,
+        command_state->AttemptGetAuthToken(test_helpers::BadPin());
+    device_tracker->CheckAndReport(Status::kErrPinAuthBlocked, returned_status,
+                                   "reject PIN before power cycle");
+    device_tracker->CheckAndReport(
+        test_helpers::GetPinRetries(device, device_tracker) ==
+            initial_counter - kWrongPinsBeforePowerCycle,
         "PIN retry counter decremented until blocked");
     returned_status =
-        command_state_->AttemptGetAuthToken(test_helpers::BadPin());
+        command_state->AttemptGetAuthToken(test_helpers::BadPin());
 
-    device_tracker_->CheckAndReport(Status::kErrPinAuthBlocked, returned_status,
-                                    "reject PIN before power cycle");
-    device_tracker_->CheckAndReport(
-        GetPinRetries() == initial_counter - kWrongPinsBeforePowerCycle,
+    device_tracker->CheckAndReport(Status::kErrPinAuthBlocked, returned_status,
+                                   "reject PIN before power cycle");
+    device_tracker->CheckAndReport(
+        test_helpers::GetPinRetries(device, device_tracker) ==
+            initial_counter - kWrongPinsBeforePowerCycle,
         "PIN retry counter does not decrement in a blocked operation");
-    command_state_->PromptReplugAndInit();
-    device_tracker_->AssertStatus(command_state_->GetAuthToken(),
-                                  "get auth token for further tests");
-    device_tracker_->CheckAndReport(
-        GetPinRetries() == initial_counter,
+    command_state->PromptReplugAndInit();
+    device_tracker->AssertStatus(command_state->GetAuthToken(),
+                                 "get auth token for further tests");
+    device_tracker->CheckAndReport(
+        test_helpers::GetPinRetries(device, device_tracker) == initial_counter,
         "PIN retries reset on entering the correct PIN");
   } else {
     std::cout << "The tests for power cycle requirement on "
@@ -275,41 +312,43 @@ void TestSeries::ClientPinRetriesTest() {
   // The next test checks whether the authenticator resets his own key agreement
   // key by reusing the old key material and see if it still works.
   returned_status =
-      command_state_->AttemptGetAuthToken(test_helpers::BadPin(), false);
-  device_tracker_->CheckAndReport(Status::kErrPinInvalid, returned_status,
-                                  "reject wrong PIN");
-  returned_status = command_state_->AttemptGetAuthToken();
-  device_tracker_->CheckAndReport(
+      command_state->AttemptGetAuthToken(test_helpers::BadPin(), false);
+  device_tracker->CheckAndReport(Status::kErrPinInvalid, returned_status,
+                                 "reject wrong PIN");
+  returned_status = command_state->AttemptGetAuthToken();
+  device_tracker->CheckAndReport(
       Status::kErrPinInvalid, returned_status,
       "reject even the correct PIN if shared secrets do not match");
-  command_state_->PromptReplugAndInit();
+  command_state->PromptReplugAndInit();
 
-  int remaining_retries = GetPinRetries();
+  int remaining_retries = test_helpers::GetPinRetries(device, device_tracker);
   for (int i = 0; i < remaining_retries - 1; ++i) {
     returned_status =
-        command_state_->AttemptGetAuthToken(test_helpers::BadPin());
+        command_state->AttemptGetAuthToken(test_helpers::BadPin());
     if (i % 3 != 2) {
-      device_tracker_->CheckAndReport(Status::kErrPinInvalid, returned_status,
-                                      "reject wrong PIN");
+      device_tracker->CheckAndReport(Status::kErrPinInvalid, returned_status,
+                                     "reject wrong PIN");
     } else {
-      device_tracker_->CheckAndReport(Status::kErrPinAuthBlocked,
-                                      returned_status, "reject wrong PIN");
-      command_state_->PromptReplugAndInit();
+      device_tracker->CheckAndReport(Status::kErrPinAuthBlocked,
+                                     returned_status, "reject wrong PIN");
+      command_state->PromptReplugAndInit();
     }
   }
-  device_tracker_->CheckAndReport(GetPinRetries() == 1,
-                                  "PIN retry counter was reduced to 1");
-  returned_status = command_state_->AttemptGetAuthToken(test_helpers::BadPin());
-  device_tracker_->CheckAndReport(Status::kErrPinBlocked, returned_status,
-                                  "block PIN retries if the counter gets to 0");
-  device_tracker_->CheckAndReport(GetPinRetries() == 0,
-                                  "PIN retry counter was reduced to 0");
-  returned_status = command_state_->AttemptGetAuthToken();
-  device_tracker_->CheckAndReport(
+  device_tracker->CheckAndReport(
+      test_helpers::GetPinRetries(device, device_tracker) == 1,
+      "PIN retry counter was reduced to 1");
+  returned_status = command_state->AttemptGetAuthToken(test_helpers::BadPin());
+  device_tracker->CheckAndReport(Status::kErrPinBlocked, returned_status,
+                                 "block PIN retries if the counter gets to 0");
+  device_tracker->CheckAndReport(
+      test_helpers::GetPinRetries(device, device_tracker) == 0,
+      "PIN retry counter was reduced to 0");
+  returned_status = command_state->AttemptGetAuthToken();
+  device_tracker->CheckAndReport(
       Status::kErrPinBlocked, returned_status,
       "reject even the correct PIN if the retry counter is 0");
 
-  command_state_->Reset();
+  command_state->Reset();
   // TODO(kaczmarczyck) check optional powerCycleState
 }
 

--- a/src/tests/test_series.h
+++ b/src/tests/test_series.h
@@ -34,70 +34,109 @@ namespace fido2_tests {
 // parameters, whenever the specification does not explicitly allow them.
 // In general, tests can also report observations or problems as side effects.
 // Example:
-//    fido2_tests::TestSeries test_series =
-//        fido2_tests::TestSeries(device, key_checker);
-//    test_series.MakeCredentialBadParameterTypesTest();
+//    fido2_tests::TestSeries test_series = fido2_tests::TestSeries();
+//    test_series.GetInfoTest(device, device_tracker, command_state);
 class TestSeries {
  public:
-  // The ownership for device and device_tracker stays with the caller and must
-  // outlive the TestSeries instance.
-  TestSeries(DeviceInterface* device, DeviceTracker* device_tracker,
-             CommandState* command_state);
-
   // Tests for MakeCredential.
 
   // Check if MakeCredential accepts different CBOR types for its parameters.
-  void MakeCredentialBadParameterTypesTest();
+  void MakeCredentialBadParameterTypesTest(DeviceInterface* device,
+                                           DeviceTracker* device_tracker,
+                                           CommandState* command_state);
   // Check if MakeCredential accepts leaving out one of the required parameters.
-  void MakeCredentialMissingParameterTest();
+  void MakeCredentialMissingParameterTest(DeviceInterface* device,
+                                          DeviceTracker* device_tracker,
+                                          CommandState* command_state);
   // Check the optional map entries of the relying party entity.
-  void MakeCredentialRelyingPartyEntityTest();
+  void MakeCredentialRelyingPartyEntityTest(DeviceInterface* device,
+                                            DeviceTracker* device_tracker,
+                                            CommandState* command_state);
   // Check the optional map entries of the user entity.
-  void MakeCredentialUserEntityTest();
+  void MakeCredentialUserEntityTest(DeviceInterface* device,
+                                    DeviceTracker* device_tracker,
+                                    CommandState* command_state);
   // Check the inner array transport elements of the exclude list.
-  void MakeCredentialExcludeListCredentialDescriptorTest();
+  void MakeCredentialExcludeListCredentialDescriptorTest(
+      DeviceInterface* device, DeviceTracker* device_tracker,
+      CommandState* command_state);
   // Check if unknown extensions are accepted.
-  void MakeCredentialExtensionsTest();
+  void MakeCredentialExtensionsTest(DeviceInterface* device,
+                                    DeviceTracker* device_tracker,
+                                    CommandState* command_state);
   // Tests if the authenticator checks the exclude list properly.
-  void MakeCredentialExcludeListTest();
+  void MakeCredentialExcludeListTest(DeviceInterface* device,
+                                     DeviceTracker* device_tracker,
+                                     CommandState* command_state);
   // Tests correct behavior with different COSE algorithms. Tests non-existing
   // algorithm identifier and type.
-  void MakeCredentialCoseAlgorithmTest();
+  void MakeCredentialCoseAlgorithmTest(DeviceInterface* device,
+                                       DeviceTracker* device_tracker,
+                                       CommandState* command_state);
   // Tests correct behavior when setting rk, up and uv.
-  void MakeCredentialOptionsTest();
+  void MakeCredentialOptionsTest(DeviceInterface* device,
+                                 DeviceTracker* device_tracker,
+                                 CommandState* command_state);
   // Tests if the PIN is correctly enforced. Resets afterwards to unset the PIN.
-  void MakeCredentialPinAuthTest();
+  void MakeCredentialPinAuthTest(DeviceInterface* device,
+                                 DeviceTracker* device_tracker,
+                                 CommandState* command_state);
   // Tests correct behavior when creating multiple keys. This test attempts to
   // create num_credentials credentials, stopping before that if the internal
   // key store is full. It resets afterwards to clear the storage.
-  void MakeCredentialMultipleKeysTest(int num_credentials);
+  void MakeCredentialMultipleKeysTest(DeviceInterface* device,
+                                      DeviceTracker* device_tracker,
+                                      CommandState* command_state,
+                                      int num_credentials);
   // Tests if the key hardware actually interacts with a user. This test can not
   // be performed automatically, but requires tester feedback.
-  void MakeCredentialPhysicalPresenceTest();
+  void MakeCredentialPhysicalPresenceTest(DeviceInterface* device,
+                                          DeviceTracker* device_tracker,
+                                          CommandState* command_state);
   // Tests if the user name is resistent to long inputs and bad UTF8.
-  void MakeCredentialDisplayNameEncodingTest();
+  void MakeCredentialDisplayNameEncodingTest(DeviceInterface* device,
+                                             DeviceTracker* device_tracker,
+                                             CommandState* command_state);
   // Tests if the HMAC-secret extension works properly.
-  void MakeCredentialHmacSecretTest();
+  void MakeCredentialHmacSecretTest(DeviceInterface* device,
+                                    DeviceTracker* device_tracker,
+                                    CommandState* command_state);
 
   // Tests for GetAssertion.
 
   // Check if GetAssertion accepts different CBOR types for its parameters.
-  void GetAssertionBadParameterTypesTest();
+  void GetAssertionBadParameterTypesTest(DeviceInterface* device,
+                                         DeviceTracker* device_tracker,
+                                         CommandState* command_state);
   // Check if GetAssertion accepts leaving out one of the required parameters.
-  void GetAssertionMissingParameterTest();
+  void GetAssertionMissingParameterTest(DeviceInterface* device,
+                                        DeviceTracker* device_tracker,
+                                        CommandState* command_state);
   // Check the inner array transport elements of the allow list.
-  void GetAssertionAllowListCredentialDescriptorTest();
+  void GetAssertionAllowListCredentialDescriptorTest(
+      DeviceInterface* device, DeviceTracker* device_tracker,
+      CommandState* command_state);
   // Check if unknown extensions are accepted.
-  void GetAssertionExtensionsTest();
+  void GetAssertionExtensionsTest(DeviceInterface* device,
+                                  DeviceTracker* device_tracker,
+                                  CommandState* command_state);
   // Tests correct behavior when setting rk, up and uv.
-  void GetAssertionOptionsTest();
+  void GetAssertionOptionsTest(DeviceInterface* device,
+                               DeviceTracker* device_tracker,
+                               CommandState* command_state);
   // Tests correct differentiation between residential and non-residential.
-  void GetAssertionResidentialKeyTest();
+  void GetAssertionResidentialKeyTest(DeviceInterface* device,
+                                      DeviceTracker* device_tracker,
+                                      CommandState* command_state);
   // Tests if the PIN is correctly enforced. Resets afterwards to unset the PIN.
-  void GetAssertionPinAuthTest();
+  void GetAssertionPinAuthTest(DeviceInterface* device,
+                               DeviceTracker* device_tracker,
+                               CommandState* command_state);
   // Tests if the key hardware actually interacts with a user. This test can not
   // be performed automatically, but requires tester feedback.
-  void GetAssertionPhysicalPresenceTest();
+  void GetAssertionPhysicalPresenceTest(DeviceInterface* device,
+                                        DeviceTracker* device_tracker,
+                                        CommandState* command_state);
 
   // TODO(kaczmarczyck) Tests for GetNextAssertion.
 
@@ -105,121 +144,76 @@ class TestSeries {
 
   // Checks if the GetInfo command has valid output implicitly. Also checks for
   // support of PIN protocol version 1, because it is used throughout all tests.
-  void GetInfoTest();
+  void GetInfoTest(DeviceInterface* device, DeviceTracker* device_tracker,
+                   CommandState* command_state);
 
   // Tests for ClientPin.
 
   // Check the input parameters of the client PIN subcommand getPinRetries.
-  void ClientPinGetPinRetriesTest();
+  void ClientPinGetPinRetriesTest(DeviceInterface* device,
+                                  DeviceTracker* device_tracker,
+                                  CommandState* command_state);
   // Check the input parameters of the client PIN subcommand getKeyAgreement.
-  void ClientPinGetKeyAgreementTest();
+  void ClientPinGetKeyAgreementTest(DeviceInterface* device,
+                                    DeviceTracker* device_tracker,
+                                    CommandState* command_state);
   // Check the input parameters of the client PIN subcommand setPin.
-  void ClientPinSetPinTest();
+  void ClientPinSetPinTest(DeviceInterface* device,
+                           DeviceTracker* device_tracker,
+                           CommandState* command_state);
   // Check the input parameters of the client PIN subcommand changePin.
-  void ClientPinChangePinTest();
+  void ClientPinChangePinTest(DeviceInterface* device,
+                              DeviceTracker* device_tracker,
+                              CommandState* command_state);
   // Check the input parameters of the client PIN subcommand
   // getPinUvAuthTokenUsingPin.
-  void ClientPinGetPinUvAuthTokenUsingPinTest();
+  void ClientPinGetPinUvAuthTokenUsingPinTest(DeviceInterface* device,
+                                              DeviceTracker* device_tracker,
+                                              CommandState* command_state);
   // Check the input parameters of the client PIN subcommand
   // getPinUvAuthTokenUsingUv. Requires CTAP 2.1, returns otherwise.
-  void ClientPinGetPinUvAuthTokenUsingUvTest();
+  void ClientPinGetPinUvAuthTokenUsingUvTest(DeviceInterface* device,
+                                             DeviceTracker* device_tracker,
+                                             CommandState* command_state);
   // Check the input parameters of the client PIN subcommand getUVRetries.
   // Requires CTAP 2.1, returns otherwise.
-  void ClientPinGetUVRetriesTest();
+  void ClientPinGetUVRetriesTest(DeviceInterface* device,
+                                 DeviceTracker* device_tracker,
+                                 CommandState* command_state);
   // Tests if the PIN minimum and maximum length are enforced correctly for the
   // SetPin and ChangePin command. Resets the device on failed tests so that the
   // following test will still find a valid state. Might end with the device
   // having a PIN set.
-  void ClientPinRequirementsTest();
+  void ClientPinRequirementsTest(DeviceInterface* device,
+                                 DeviceTracker* device_tracker,
+                                 CommandState* command_state);
   // Tests PIN protocol requirements introduced in CTAP 2.1. This includes
   // testing different padding lengths for SetPin and ChangePin. Resets the
   // device before tests and on failed tests. Might end with the device having a
   // PIN set.
-  void ClientPinRequirements2Point1Test();
+  void ClientPinRequirements2Point1Test(DeviceInterface* device,
+                                        DeviceTracker* device_tracker,
+                                        CommandState* command_state);
   // Tests if retries decrement properly and respond with correct error codes.
   // Creates a PIN if necessary. Resets the device at the beginning and the end.
-  void ClientPinRetriesTest();
+  void ClientPinRetriesTest(DeviceInterface* device,
+                            DeviceTracker* device_tracker,
+                            CommandState* command_state);
 
   // Tests for Reset.
 
-  // Only tests the returned status code, just resets the authenticator.
-  // Replugging the device before calling the function is necessary.
-  void Reset();
   // Tests if the state on the device is wiped out.
   // Replugging the device before calling the function is necessary.
-  void ResetDeletionTest();
+  void ResetDeletionTest(DeviceInterface* device, DeviceTracker* device_tracker,
+                         CommandState* command_state);
   // Tests if requirements for resetting are enforced.
-  void ResetPhysicalPresenceTest();
+  void ResetPhysicalPresenceTest(DeviceInterface* device,
+                                 DeviceTracker* device_tracker,
+                                 CommandState* command_state);
   // Tests if the state is persistent when being replugged. This includes
   // credentials and the PIN retries.
-  void PersistenceTest();
-
- private:
-  // TODO(#16) replace version string with FIDO_2_1 when specification is final
-  bool IsFido2Point1Complicant();
-  // Makes a credential for all tests that require one, for example assertions.
-  cbor::Value MakeTestCredential(const std::string& rp_id,
-                                 bool use_residential_key);
-
-  // The following helper functions are used to test input parameters.
-
-  // Tries to insert types other than the correct one into the CBOR builder.
-  // Make sure to pass the appropriate CborBuilder for your command. The correct
-  // types are inferred through the currently present builder entries. The tests
-  // include other types than maps for the command and inner types of maps and
-  // the first element of an inner array (assuming all array elements have the
-  // same type). If that first element happens to be a map, its entries are also
-  // checked. Even though this seems like an arbitrary choice at first, it
-  // covers most of the CTAP input.
-  void TestBadParameterTypes(Command command, CborBuilder* builder);
-  // Tries to remove each parameter once. Make sure to pass the appropriate
-  // CborBuilder for your command. The necessary parameters are inferred through
-  // the currently present builder entries.
-  void TestMissingParameters(Command command, CborBuilder* builder);
-  // Tries to insert types other than the correct one into map entries. Those
-  // maps themselves are values of the command parameter map. If
-  // has_wrapping_array is true, the inner map is used as an array element
-  // instead. To sum it up, the data structure tested can look like this:
-  // command:outer_map_key->inner_map[key]->wrongly_typed_value or
-  // command:outer_map_key->[inner_map[key]->wrongly_typed_value].
-  void TestBadParametersInInnerMap(Command command, CborBuilder* builder,
-                                   int outer_map_key,
-                                   const cbor::Value::MapValue& inner_map,
-                                   bool has_wrapping_array);
-  // Tries to insert types other than the correct one into array elements. Those
-  // arrays themselves are values of the command parameter map.
-  void TestBadParametersInInnerArray(Command command, CborBuilder* builder,
-                                     int outer_map_key,
-                                     const cbor::Value& array_element);
-  // Tries to insert a map or an array as a transport in an array of public key
-  // credential descriptors. Both excludeList in MakeCredential and allowList in
-  // GetAssertion expect this kind of value and share this test. Authenticators
-  // must ignore unknown items in the transports list, so unexpected types are
-  // untested. For arrays and maps though, the maximum nesting depth is reached.
-  void TestCredentialDescriptorsArrayForCborDepth(Command command,
-                                                  CborBuilder* builder,
-                                                  int map_key,
-                                                  const std::string& rp_id);
-
-  // The following helper functions are used to test command behaviour.
-
-  // Gets and checks the PIN retry counter response from the authenticator.
-  int GetPinRetries();
-  // Checks if the PIN we currently assume is set works for getting an auth
-  // token. This way, we don't have to trust only the returned status code
-  // after a SetPin or ChangePin command. It does not actually return an auth
-  // token, use GetAuthToken() in that case.
-  void CheckPinByGetAuthToken();
-  // Checks if the PIN is not currently set by trying to make a credential.
-  // The MakeCredential command should fail when the authenticator is PIN
-  // protected. Even though this test could fail in case of a bad implementation
-  // of Make Credential, this kind of misbehavior would be caught in another
-  // test.
-  void CheckPinAbsenceByMakeCredential();
-
-  DeviceInterface* device_;
-  DeviceTracker* device_tracker_;
-  CommandState* command_state_;
+  void PersistenceTest(DeviceInterface* device, DeviceTracker* device_tracker,
+                       CommandState* command_state);
 };
 
 namespace test_helpers {
@@ -238,6 +232,79 @@ int ExtractPinRetries(const cbor::Value& response);
 void PrintByteVector(const cbor::Value::BinaryValue& vec);
 
 void PrintNoTouchPrompt();
+
+// TODO(#16) replace version string with FIDO_2_1 when specification is final
+bool IsFido2Point1Complicant(DeviceTracker* device_tracker);
+
+// Makes a credential for all tests that require one, for example assertions.
+cbor::Value MakeTestCredential(DeviceTracker* device_tracker,
+                               CommandState* command_state,
+                               const std::string& rp_id,
+                               bool use_residential_key);
+
+// The following helper functions are used to test input parameters.
+
+// Tries to insert types other than the correct one into the CBOR builder.
+// Make sure to pass the appropriate CborBuilder for your command. The correct
+// types are inferred through the currently present builder entries. The tests
+// include other types than maps for the command and inner types of maps and
+// the first element of an inner array (assuming all array elements have the
+// same type). If that first element happens to be a map, its entries are also
+// checked. Even though this seems like an arbitrary choice at first, it
+// covers most of the CTAP input.
+void TestBadParameterTypes(DeviceInterface* device,
+                           DeviceTracker* device_tracker, Command command,
+                           CborBuilder* builder);
+// Tries to remove each parameter once. Make sure to pass the appropriate
+// CborBuilder for your command. The necessary parameters are inferred through
+// the currently present builder entries.
+void TestMissingParameters(DeviceInterface* device,
+                           DeviceTracker* device_tracker, Command command,
+                           CborBuilder* builder);
+// Tries to insert types other than the correct one into map entries. Those
+// maps themselves are values of the command parameter map. If
+// has_wrapping_array is true, the inner map is used as an array element
+// instead. To sum it up, the data structure tested can look like this:
+// command:outer_map_key->inner_map[key]->wrongly_typed_value or
+// command:outer_map_key->[inner_map[key]->wrongly_typed_value].
+void TestBadParametersInInnerMap(DeviceInterface* device,
+                                 DeviceTracker* device_tracker, Command command,
+                                 CborBuilder* builder, int outer_map_key,
+                                 const cbor::Value::MapValue& inner_map,
+                                 bool has_wrapping_array);
+// Tries to insert types other than the correct one into array elements. Those
+// arrays themselves are values of the command parameter map.
+void TestBadParametersInInnerArray(DeviceInterface* device,
+                                   DeviceTracker* device_tracker,
+                                   Command command, CborBuilder* builder,
+                                   int outer_map_key,
+                                   const cbor::Value& array_element);
+// Tries to insert a map or an array as a transport in an array of public key
+// credential descriptors. Both excludeList in MakeCredential and allowList in
+// GetAssertion expect this kind of value and share this test. Authenticators
+// must ignore unknown items in the transports list, so unexpected types are
+// untested. For arrays and maps though, the maximum nesting depth is reached.
+void TestCredentialDescriptorsArrayForCborDepth(
+    DeviceInterface* device, DeviceTracker* device_tracker, Command command,
+    CborBuilder* builder, int map_key, const std::string& rp_id);
+
+// The following helper functions are used to test command behaviour.
+
+// Gets and checks the PIN retry counter response from the authenticator.
+int GetPinRetries(DeviceInterface* device, DeviceTracker* device_tracker);
+// Checks if the PIN we currently assume is set works for getting an auth
+// token. This way, we don't have to trust only the returned status code
+// after a SetPin or ChangePin command. It does not actually return an auth
+// token, use GetAuthToken() in that case.
+void CheckPinByGetAuthToken(DeviceTracker* device_tracker,
+                            CommandState* command_state);
+// Checks if the PIN is not currently set by trying to make a credential.
+// The MakeCredential command should fail when the authenticator is PIN
+// protected. Even though this test could fail in case of a bad implementation
+// of Make Credential, this kind of misbehavior would be caught in another
+// test.
+void CheckPinAbsenceByMakeCredential(DeviceInterface* device,
+                                     DeviceTracker* device_tracker);
 
 }  // namespace test_helpers
 


### PR DESCRIPTION
Next commit after #34, removing all private members from `TestSeries`, so that is it only a collection of public member functions. They will move to their own classes and register in a map to de-clutter main later.