### PR TITLE
Updates response keys to 2.1

### DIFF
--- a/src/constants.cc
+++ b/src/constants.cc
@@ -134,16 +134,30 @@ cbor::Value CborValue(MakeCredentialResponse response) {
   return cbor::Value(static_cast<uint8_t>(response));
 }
 
+bool MakeCredentialResponseContains(int64_t key) {
+  return key >= 0x01 && key <= 0x05;
+}
+
 cbor::Value CborValue(GetAssertionResponse response) {
   return cbor::Value(static_cast<uint8_t>(response));
+}
+
+bool GetAssertionResponseContains(int64_t key) {
+  return key >= 0x01 && key <= 0x07;
 }
 
 cbor::Value CborValue(InfoMember response) {
   return cbor::Value(static_cast<uint8_t>(response));
 }
 
+bool InfoMemberContains(int64_t key) { return key >= 0x01 && key <= 0x15; }
+
 cbor::Value CborValue(ClientPinResponse response) {
   return cbor::Value(static_cast<uint8_t>(response));
+}
+
+bool ClientPinResponseContains(int64_t key) {
+  return key >= 0x01 && key <= 0x05;
 }
 
 }  // namespace fido2_tests

--- a/src/constants.h
+++ b/src/constants.h
@@ -155,10 +155,15 @@ enum class MakeCredentialResponse : uint8_t {
   kFmt = 0x01,
   kAuthData = 0x02,
   kAttStmt = 0x03,
+  kEpAtt = 0x04,
+  kLargeBlobKey = 0x05,
 };
 
 // Converts a MakeCredential response key to a cbor::Value.
 cbor::Value CborValue(MakeCredentialResponse response);
+
+// Checks if the key is used in this enum.
+bool MakeCredentialResponseContains(int64_t key);
 
 // Contains the map keys for GetAssertion responses.
 enum class GetAssertionResponse : uint8_t {
@@ -167,10 +172,15 @@ enum class GetAssertionResponse : uint8_t {
   kSignature = 0x03,
   kUser = 0x04,
   kNumberOfCredentials = 0x05,
+  kUserSelected = 0x06,
+  kLargeBlobKey = 0x07,
 };
 
 // Converts a GetAssertion response key to a cbor::Value.
 cbor::Value CborValue(GetAssertionResponse response);
+
+// Checks if the key is used in this enum.
+bool GetAssertionResponseContains(int64_t key);
 
 // Contains the map keys for GetInfo responses.
 enum class InfoMember : uint8_t {
@@ -185,17 +195,23 @@ enum class InfoMember : uint8_t {
   kTransports = 0x09,
   kAlgorithms = 0x0A,
   kMaxSerializedLargeBlobArray = 0x0B,
-  // 0x0C is intentionally missing.
+  kForcePinChange = 0x0C,
   kMinPinLength = 0x0D,
   kFirmwareVersion = 0x0E,
   kMaxCredBlobLength = 0x0F,
   kMaxRpIdsForSetMinPinLength = 0x10,
   kPreferredPlatformUvAttempts = 0x11,
   kUvModality = 0x12,
+  kCertifications = 0x13,
+  kRemainingDiscoverableCredentials = 0x14,
+  kVendorPrototypeConfigCommands = 0x15,
 };
 
 // Converts a GetInfo response key to a cbor::Value.
 cbor::Value CborValue(InfoMember response);
+
+// Checks if the key is used in this enum.
+bool InfoMemberContains(int64_t key);
 
 // Contains the map keys for ClientPin responses.
 enum class ClientPinResponse : uint8_t {
@@ -208,6 +224,9 @@ enum class ClientPinResponse : uint8_t {
 
 // Converts a ClientPin response key to a cbor::Value.
 cbor::Value CborValue(ClientPinResponse response);
+
+// Checks if the key is used in this enum.
+bool ClientPinResponseContains(int64_t key);
 
 }  // namespace fido2_tests
 

--- a/src/fido2_commands.cc
+++ b/src/fido2_commands.cc
@@ -316,9 +316,16 @@ absl::variant<cbor::Value, Status> MakeCredentialPositiveTest(
   }
 
   for (const auto& map_entry : decoded_map) {
-    CHECK(map_entry.first.is_unsigned()) << "some map keys are not unsigned";
-    const int64_t map_key = map_entry.first.GetUnsigned();
-    CHECK(map_key >= 1 && map_key <= 3) << "there are unspecified map keys";
+    if (map_entry.first.is_unsigned()) {
+      const int64_t map_key = map_entry.first.GetUnsigned();
+      if (!MakeCredentialResponseContains(map_key)) {
+        device_tracker->AddObservation(absl::StrCat(
+            "Received unspecified MakeCredential map key ", map_key, "."));
+      }
+    } else {
+      device_tracker->AddObservation(
+          "Some MakeCredential map keys are not unsigned.");
+    }
   }
 
   return decoded_response->Clone();
@@ -454,9 +461,16 @@ absl::variant<cbor::Value, Status> GetAssertionPositiveTest(
   }
 
   for (const auto& map_entry : decoded_map) {
-    CHECK(map_entry.first.is_unsigned()) << "some map keys are not unsigned";
-    const int64_t map_key = map_entry.first.GetUnsigned();
-    CHECK(map_key >= 1 && map_key <= 5) << "there are unspecified map keys";
+    if (map_entry.first.is_unsigned()) {
+      const int64_t map_key = map_entry.first.GetUnsigned();
+      if (!GetAssertionResponseContains(map_key)) {
+        device_tracker->AddObservation(absl::StrCat(
+            "Received unspecified GetAssertion map key ", map_key, "."));
+      }
+    } else {
+      device_tracker->AddObservation(
+          "Some GetAssertion map keys are not unsigned.");
+    }
   }
 
   return decoded_response->Clone();
@@ -607,6 +621,11 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
         << "maxSerializedLargeBlobArray is too small";
   }
 
+  map_iter = decoded_map.find(CborValue(InfoMember::kForcePinChange));
+  if (map_iter != decoded_map.end()) {
+    CHECK(map_iter->second.is_bool()) << "forcePINChangeentry is not a bool";
+  }
+
   map_iter = decoded_map.find(CborValue(InfoMember::kMinPinLength));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_unsigned())
@@ -648,11 +667,40 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
         << "uvModality entry is not an unsigned";
   }
 
+  map_iter = decoded_map.find(CborValue(InfoMember::kCertifications));
+  if (map_iter != decoded_map.end()) {
+    CHECK(map_iter->second.is_map()) << "certifications entry is not a map";
+  }
+
+  map_iter = decoded_map.find(
+      CborValue(InfoMember::kRemainingDiscoverableCredentials));
+  if (map_iter != decoded_map.end()) {
+    CHECK(map_iter->second.is_unsigned())
+        << "remainingDiscoverableCredentials entry is not an unsigned";
+  }
+
+  map_iter =
+      decoded_map.find(CborValue(InfoMember::kVendorPrototypeConfigCommands));
+  if (map_iter != decoded_map.end()) {
+    CHECK(map_iter->second.is_array())
+        << "vendorPrototypeConfigCommands entry is not an array";
+    for (const auto& command : map_iter->second.GetArray()) {
+      CHECK(command.is_unsigned())
+          << "vendorPrototypeConfigCommands elements are not unsigned";
+    }
+  }
+
   for (const auto& map_entry : decoded_map) {
-    CHECK(map_entry.first.is_unsigned()) << "some map keys are not unsigned";
-    const int64_t map_key = map_entry.first.GetUnsigned();
-    CHECK(map_key >= 0x01 && map_key <= 0x12 && map_key != 0x0C)
-        << "there are unspecified map keys";
+    if (map_entry.first.is_unsigned()) {
+      const int64_t map_key = map_entry.first.GetUnsigned();
+      if (!InfoMemberContains(map_key)) {
+        device_tracker->AddObservation(
+            absl::StrCat("Received unspecified GetInfo map key ",
+                         absl::Hex(map_key, absl::kZeroPad2), "."));
+      }
+    } else {
+      device_tracker->AddObservation("Some GetInfo map keys are not unsigned.");
+    }
   }
 
   device_tracker->Initialize(versions, extensions, options);
@@ -764,11 +812,18 @@ absl::variant<cbor::Value, Status> AuthenticatorClientPinPositiveTest(
   // Check for unexpected map keys.
   if (has_response_cbor) {
     for (const auto& map_entry : decoded_map) {
-      CHECK(map_entry.first.is_unsigned()) << "some map keys are not unsigned";
-      const int64_t map_key = map_entry.first.GetUnsigned();
-      CHECK(map_key <= UINT8_MAX &&
-            allowed_map_keys.contains(static_cast<ClientPinResponse>(map_key)))
-          << "there are unspecified map keys";
+      if (map_entry.first.is_unsigned()) {
+        const int64_t map_key = map_entry.first.GetUnsigned();
+        if (!GetAssertionResponseContains(map_key) ||
+            !allowed_map_keys.contains(
+                static_cast<ClientPinResponse>(map_key))) {
+          device_tracker->AddObservation(absl::StrCat(
+              "Received unspecified ClientPin map key ", map_key, "."));
+        }
+      } else {
+        device_tracker->AddObservation(
+            "Some ClientPin map keys are not unsigned.");
+      }
     }
   }
 

--- a/src/tests/general.cc
+++ b/src/tests/general.cc
@@ -101,7 +101,8 @@ PersistentPinRetriesTest::PersistentPinRetriesTest()
 std::optional<std::string> PersistentPinRetriesTest::Execute(
     DeviceInterface* device, DeviceTracker* device_tracker,
     CommandState* command_state) const {
-  if (device_tracker->CheckStatus(
+  if (!device_tracker->CheckStatus(
+          Status::kErrPinInvalid,
           command_state->AttemptGetAuthToken(test_helpers::BadPin()))) {
     return "GetAuthToken did not fail with the wrong PIN.";
   }

--- a/src/tests/reset.cc
+++ b/src/tests/reset.cc
@@ -89,7 +89,8 @@ std::optional<std::string> DeletePinTest::Execute(
   if (absl::holds_alternative<std::string>(initial_counter)) {
     return absl::get<std::string>(initial_counter);
   }
-  if (device_tracker->CheckStatus(
+  if (!device_tracker->CheckStatus(
+          Status::kErrPinInvalid,
           command_state->AttemptGetAuthToken(test_helpers::BadPin()))) {
     return "GetAuthToken did not fail with the wrong PIN.";
   }


### PR DESCRIPTION
This PR makes the command checks accept unknown keys in response maps, and just adds a note. Also, more keys are considered "known", to allow test keys for CTAP 2.1 to pass without problems.

On a side note, I fixed a `CheckStatus` inconsistency I noticed during testing.