### PR TITLE
Changed documentation and bash script for fuzzing

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -18,8 +18,9 @@ out common solutions such as hardware emulation or binary instrumentation.
 Our idea is fuzzing by proxy. We take [OpenSK](https://github.com/google/OpenSK)
 (an open source implementation of a FIDO2 security key) as our fuzz target and 
 generate interesting input data guided by OpenSK's code coverage. At the moment,
-the fuzzing tool consists of running this input corpus on the device under test. 
-You can also use your own data set for testing.
+the fuzzing tool consists of running this input corpus on the device under test.
+The corpus is hosted at a [git repository](https://github.com/mingxguo27/test_corpus)
+and integrated as a submodule. You can also use your own data set for testing.
 
 ## Device monitoring
 

--- a/run_fuzzing.sh
+++ b/run_fuzzing.sh
@@ -21,11 +21,38 @@
 # 3. Monitor type.
 # 4. Connection port for the GDB server, if it's used.
 
-path=${1:-_}
-corpus=${2:-corpus_tests/test_corpus/}
-monitor=${3:-blackbox}
-port=${4:-2331}
+path=_
+corpus=corpus_tests/test_corpus/
+monitor=blackbox
+port=2331
 
-git submodule init
-git submodule update
+# parse parameters
+for arg in "$@"
+do
+case $arg in
+    --token_path=*)
+    path="${arg#*=}"
+    shift
+    ;;
+    --corpus_path=*)
+    corpus="${arg#*=}"
+    shift
+    ;;
+    --monitor=*)
+    monitor="${arg#*=}"
+    shift
+    ;;
+    --port=*)
+    port="${arg#*=}"
+    shift
+    ;;
+esac
+done
+
+if [ "$corpus" = "corpus_tests/test_corpus/" ]
+then
+    git submodule init
+    git submodule update
+fi
+
 bazel run //:corpus_test -- --token_path="$path" --corpus_path="$corpus" --monitor="$monitor" --port="$port"


### PR DESCRIPTION
Refactored bash script:
- keyword argument parsing instead of positional argument parsing. 
- only initialising submodule when default corpus activated.

TODO: Update documentation link to the real repository. #63 