### PR TITLE
Extending device interface with sending CTAPHID raw data method.

### DIFF
--- a/src/device_interface.h
+++ b/src/device_interface.h
@@ -39,6 +39,10 @@ class DeviceInterface {
                               const std::vector<uint8_t>& payload,
                               bool expect_up_check,
                               std::vector<uint8_t>* response_cbor) const = 0;
+  // Sends a CTAPHID raw message to the device. Returns the response if received
+  // one.
+  virtual Status SendCtapHid(const std::vector<uint8_t>& payload,
+                             std::vector<uint8_t>* response) const = 0;
 };
 
 // Contains all device identifier for logging and to re-identify the device.

--- a/src/fuzzing/fuzzing_helpers.cc
+++ b/src/fuzzing/fuzzing_helpers.cc
@@ -16,7 +16,7 @@ std::string InputTypeToDirectoryName(InputType input_type) {
       return "Cbor_ClientPinParameters";
     case InputType::kCborRaw:
       return "Cbor_Raw";
-    case InputType::kRawData:
+    case InputType::kCtapHidRaw:
       return "CtapHidRawData";
     default:
       CHECK(false) << "unreachable default - TEST SUITE BUG";
@@ -37,6 +37,8 @@ Status SendInput(DeviceInterface* device, InputType input_type,
     case InputType::kCborClientPinParameter:
       return device->ExchangeCbor(Command::kAuthenticatorClientPIN, input,
                                   false, &response);
+    case InputType::kCtapHidRaw:
+      return device->SendCtapHid(input, &response);
     default:
       return Status::kErrOther;
   }

--- a/src/fuzzing/fuzzing_helpers.h
+++ b/src/fuzzing/fuzzing_helpers.h
@@ -30,7 +30,7 @@ enum InputType {
   kCborGetAssertionParameter,
   kCborClientPinParameter,
   kCborRaw,
-  kRawData
+  kCtapHidRaw
 };
 
 struct FuzzingOptions {

--- a/src/hid/hid_device.h
+++ b/src/hid/hid_device.h
@@ -85,6 +85,10 @@ class HidDevice : public DeviceInterface {
   Status ExchangeCbor(Command command, const std::vector<uint8_t>& payload,
                       bool expect_up_check,
                       std::vector<uint8_t>* response_cbor) const override;
+  // Sends and potentially receives any CTAPHID raw message including the
+  // command byte over the allocated channel.
+  Status SendCtapHid(const std::vector<uint8_t>& payload,
+                     std::vector<uint8_t>* response) const override;
 
  private:
   // A received response can be status 0, an error, or a keepalive in case the

--- a/src/hid/hid_device.h
+++ b/src/hid/hid_device.h
@@ -96,6 +96,13 @@ class HidDevice : public DeviceInterface {
   // Waits for incoming frames, returning their content in an output parameter.
   Status ReceiveCommand(absl::Duration timeout, uint8_t* cmd,
                         std::vector<uint8_t>* data) const;
+  // Sends a CTAPHID command and awaits for a response determined by the given
+  // flags. Reports an unexpected response or returns the content otherwise.
+  Status SendRecvCommand(uint8_t send_cmd,
+                         const std::vector<uint8_t>& send_data,
+                         std::vector<uint8_t>* recv_data, bool expect_response,
+                         bool expect_status, bool expect_empty_data,
+                         bool expect_up_check) const;
   // The lowest abstraction layer, just sends a single frame.
   Status SendFrame(Frame* frame) const;
   // The lowest abstraction layer, receives a single frame with in a given time.

--- a/src/tests/fuzzing_corpus.cc
+++ b/src/tests/fuzzing_corpus.cc
@@ -143,5 +143,25 @@ void ClientPinCorpusTest::Setup(CommandState* command_state) const {
   ::fido2_tests::Setup(command_state, monitor_);
 }
 
+CtapHidCorpusTest::CtapHidCorpusTest(Monitor* monitor,
+                                     const std::string_view& base_corpus_path)
+    : BaseTest("ctap_hid_corpus", "Tests the corpus of CTAPHID raw messages.",
+               {.has_pin = false}, {Tag::kFuzzing}),
+      monitor_(monitor),
+      base_corpus_path_(base_corpus_path) {}
+
+std::optional<std::string> CtapHidCorpusTest::Execute(
+    DeviceInterface* device, DeviceTracker* device_tracker,
+    CommandState* command_state) const {
+  return ::fido2_tests::Execute(device, device_tracker, command_state, monitor_,
+                                fuzzing_helpers::InputType::kCtapHidRaw,
+                                base_corpus_path_);
+}
+
+void CtapHidCorpusTest::Setup(CommandState* command_state) const {
+  BaseTest::Setup(command_state);
+  ::fido2_tests::Setup(command_state, monitor_);
+}
+
 }  // namespace fido2_tests
 

--- a/src/tests/fuzzing_corpus.h
+++ b/src/tests/fuzzing_corpus.h
@@ -68,6 +68,21 @@ class ClientPinCorpusTest : public BaseTest {
   std::string_view base_corpus_path_;
 };
 
+// Tests the corpus of ctap hid raw data.
+class CtapHidCorpusTest : public BaseTest {
+ public:
+  CtapHidCorpusTest(fido2_tests::Monitor* monitor,
+                    const std::string_view& base_corpus_path);
+  std::optional<std::string> Execute(
+      DeviceInterface* device, DeviceTracker* device_tracker,
+      CommandState* command_state) const override;
+  void Setup(CommandState* command_state) const override;
+
+ private:
+  fido2_tests::Monitor* monitor_;
+  std::string_view base_corpus_path_;
+};
+
 }  // namespace fido2_tests
 
 #endif  // TESTS_FUZZING_CORPUS_H_

--- a/src/tests/test_series.cc
+++ b/src/tests/test_series.cc
@@ -145,6 +145,8 @@ const std::vector<std::unique_ptr<BaseTest>>& GetCorpusTests(
         std::make_unique<GetAssertionCorpusTest>(monitor, base_corpus_path));
     test_list->push_back(
         std::make_unique<ClientPinCorpusTest>(monitor, base_corpus_path));
+    test_list->push_back(
+        std::make_unique<CtapHidCorpusTest>(monitor, base_corpus_path));
     return test_list;
   }();
   return *tests;


### PR DESCRIPTION
The current version consider CTAPHID raw data without the CID bytes. I can extend the function to include the CIDs as well, depending on the needs.

