### PR TITLE
adds retries for Reset, since replugging can be flaky

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -141,6 +141,7 @@ cc_library(
         ":fido2_commands",
         "//third_party/chromium_components_cbor:cbor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:variant",
         "@com_google_glog//:glog",
     ],

--- a/src/device_tracker.cc
+++ b/src/device_tracker.cc
@@ -153,6 +153,9 @@ void DeviceTracker::AddObservation(const std::string& observation) {
 void DeviceTracker::AssertCondition(bool condition, std::string_view message) {
   if (!condition) {
     SaveResultsToFile();
+    for (std::string_view observation : observations_) {
+      PrintWarningMessage(observation);
+    }
   }
   CHECK(condition) << "Failed critical condition: " << message;
 }


### PR DESCRIPTION
Reset is executed quite often, and always preceded by replugging. This can lead to random failures during device bootup. To minimize these, we allow retrying. And print all observations, in case it still fails.