### PR TITLE
Remove 2.1 tag from empty PIN auth tests

### DIFF
--- a/src/tests/get_assertion.cc
+++ b/src/tests/get_assertion.cc
@@ -408,7 +408,7 @@ GetAssertionPinAuthEmptyTest::GetAssertionPinAuthEmptyTest()
     : BaseTest("get_assertion_pin_auth_empty",
                "Tests the response on an empty PIN auth without a PIN in "
                "GetAssertion.",
-               {.has_pin = false}, {Tag::kClientPin, Tag::kFido2Point1}) {}
+               {.has_pin = false}, {Tag::kClientPin}) {}
 
 std::optional<std::string> GetAssertionPinAuthEmptyTest::Execute(
     DeviceInterface* device, DeviceTracker* device_tracker,
@@ -490,7 +490,7 @@ GetAssertionPinAuthEmptyWithPinTest::GetAssertionPinAuthEmptyWithPinTest()
     : BaseTest(
           "get_assertion_pin_auth_empty_with_pin",
           "Tests the response on an empty PIN auth with a PIN in GetAssertion.",
-          {.has_pin = true}, {Tag::kClientPin, Tag::kFido2Point1}) {}
+          {.has_pin = true}, {Tag::kClientPin}) {}
 
 std::optional<std::string> GetAssertionPinAuthEmptyWithPinTest::Execute(
     DeviceInterface* device, DeviceTracker* device_tracker,

--- a/src/tests/make_credential.cc
+++ b/src/tests/make_credential.cc
@@ -496,7 +496,7 @@ MakeCredentialPinAuthEmptyTest::MakeCredentialPinAuthEmptyTest()
     : BaseTest("make_credential_pin_auth_empty",
                "Tests the response on an empty PIN auth without a PIN in "
                "MakeCredential.",
-               {.has_pin = false}, {Tag::kClientPin, Tag::kFido2Point1}) {}
+               {.has_pin = false}, {Tag::kClientPin}) {}
 
 std::optional<std::string> MakeCredentialPinAuthEmptyTest::Execute(
     DeviceInterface* device, DeviceTracker* device_tracker,
@@ -562,7 +562,7 @@ MakeCredentialPinAuthEmptyWithPinTest::MakeCredentialPinAuthEmptyWithPinTest()
     : BaseTest("make_credential_pin_auth_empty_with_pin",
                "Tests the response on an empty PIN auth with a PIN in "
                "MakeCredential.",
-               {.has_pin = true}, {Tag::kClientPin, Tag::kFido2Point1}) {}
+               {.has_pin = true}, {Tag::kClientPin}) {}
 
 std::optional<std::string> MakeCredentialPinAuthEmptyWithPinTest::Execute(
     DeviceInterface* device, DeviceTracker* device_tracker,


### PR DESCRIPTION
I discovered (with Nina's help) that this behaviour is already documented in 2.0.