### PR TITLE
Add UP as a default option

### DIFF
--- a/src/device_tracker.cc
+++ b/src/device_tracker.cc
@@ -105,6 +105,14 @@ void DeviceTracker::Initialize(const cbor::Value::ArrayValue& versions,
       }
     }
   }
+
+  std::vector<std::string> default_true_options = {"up"};
+  for (const std::string& option : default_true_options) {
+    auto iter = options.find(cbor::Value(option));
+    if (iter == options.end()) {
+      options_.insert(option);
+    }
+  }
 }
 
 bool DeviceTracker::HasVersion(std::string_view version_name) const {

--- a/src/device_tracker.h
+++ b/src/device_tracker.h
@@ -136,6 +136,7 @@ class DeviceTracker {
   absl::flat_hash_set<std::string> extensions_;
   // Some options have three states, unsupported, inactive and active.
   // We only care about being supported in general, and activate as necessary.
+  // Also, options that default to true are always initialized.
   absl::flat_hash_set<std::string> options_;
   bool is_initialized_ = false;
   bool has_wink_capability_ = false;

--- a/src/device_tracker_test.cc
+++ b/src/device_tracker_test.cc
@@ -45,6 +45,16 @@ TEST(DeviceTracker, TestInitialize) {
   EXPECT_TRUE(device_tracker.HasOption("bioEnroll"));
 }
 
+TEST(DeviceTracker, TestInitializeDefault) {
+  DeviceTracker device_tracker = DeviceTracker();
+  cbor::Value::ArrayValue versions;
+  cbor::Value::ArrayValue extensions;
+  cbor::Value::MapValue options;
+
+  device_tracker.Initialize(versions, extensions, options);
+  EXPECT_TRUE(device_tracker.HasOption("up"));
+}
+
 TEST(DeviceTracker, TestCheckStatusOneArgument) {
   DeviceTracker device_tracker = DeviceTracker();
   EXPECT_TRUE(device_tracker.CheckStatus(Status::kErrNone));
@@ -78,7 +88,7 @@ TEST(DeviceTracker, TestGenerateResultsJson) {
   cbor::Value::ArrayValue extensions;
   extensions.push_back(cbor::Value("EXTENSION"));
   cbor::Value::MapValue options;
-  options[cbor::Value("OPTION")] = cbor::Value(true);
+  options[cbor::Value("up")] = cbor::Value(true);
 
   device_tracker.Initialize(versions, extensions, options);
   device_tracker.SetDeviceIdentifiers({.manufacturer = "M",
@@ -136,7 +146,7 @@ TEST(DeviceTracker, TestGenerateResultsJson) {
           "capabilities",
           {
               {"versions", {"VERSION"}},
-              {"options", {"OPTION"}},
+              {"options", {"up"}},
               {"extensions", {"EXTENSION"}},
               {"wink", true},
               {"cbor", true},


### PR DESCRIPTION
Fixes #85 

@cheburashka Can you please test and confirm it works with this PR? I didn't have a security key that doesn't report the UP capability, so I didn't notice. I tested this PR with an OpenSK that doesn't report `UP` and it seems to work.