### PR TITLE
Remove CBOR nesting depth tests

### DIFF
--- a/src/tests/get_assertion.cc
+++ b/src/tests/get_assertion.cc
@@ -84,27 +84,6 @@ std::optional<std::string> GetAssertionMissingParameterTest::Execute(
       &missing_required_builder);
 }
 
-GetAssertionAllowListDepthTest::GetAssertionAllowListDepthTest()
-    : BaseTest("get_assertion_allow_list_depth",
-               "Tests nested CBOR in the allow list of GetAssertion.",
-               {.has_pin = false}, {}) {}
-
-std::optional<std::string> GetAssertionAllowListDepthTest::Execute(
-    DeviceInterface* device, DeviceTracker* device_tracker,
-    CommandState* command_state) const {
-  if (!device_tracker->CheckStatus(
-          command_state->MakeTestCredential(RpId(), true))) {
-    return "Cannot make credential for further tests.";
-  }
-
-  GetAssertionCborBuilder allow_list_builder;
-  allow_list_builder.AddDefaultsForRequiredFields(RpId());
-  return test_helpers::TestCredentialDescriptorsArrayForCborDepth(
-      device, device_tracker, Command::kAuthenticatorGetAssertion,
-      &allow_list_builder, static_cast<int>(GetAssertionParameters::kAllowList),
-      RpId());
-}
-
 GetAssertionAllowListCredentialDescriptorTest::
     GetAssertionAllowListCredentialDescriptorTest()
     : BaseTest(

--- a/src/tests/get_assertion.h
+++ b/src/tests/get_assertion.h
@@ -28,9 +28,6 @@ TEST_CLASS(GetAssertionBadParameterTypesTest);
 // Tests if GetAssertion works with missing parameters.
 TEST_CLASS(GetAssertionMissingParameterTest);
 
-// Tests nested CBOR in the allow list of GetAssertion.
-TEST_CLASS(GetAssertionAllowListDepthTest);
-
 // Tests credential descriptors in the allow list of GetAssertion.
 TEST_CLASS(GetAssertionAllowListCredentialDescriptorTest);
 

--- a/src/tests/make_credential.cc
+++ b/src/tests/make_credential.cc
@@ -181,22 +181,6 @@ std::optional<std::string> MakeCredentialUserEntityTest::Execute(
   return std::nullopt;
 }
 
-MakeCredentialExcludeListDepth::MakeCredentialExcludeListDepth()
-    : BaseTest("make_credential_exclude_list_depth",
-               "Tests nested CBOR in the exclude list of MakeCredential.",
-               {.has_pin = false}, {}) {}
-
-std::optional<std::string> MakeCredentialExcludeListDepth::Execute(
-    DeviceInterface* device, DeviceTracker* device_tracker,
-    CommandState* command_state) const {
-  MakeCredentialCborBuilder exclude_list_builder;
-  exclude_list_builder.AddDefaultsForRequiredFields(RpId());
-  return test_helpers::TestCredentialDescriptorsArrayForCborDepth(
-      device, device_tracker, Command::kAuthenticatorMakeCredential,
-      &exclude_list_builder,
-      static_cast<int>(MakeCredentialParameters::kExcludeList), RpId());
-}
-
 MakeCredentialExcludeListCredentialDescriptorTest::
     MakeCredentialExcludeListCredentialDescriptorTest()
     : BaseTest(

--- a/src/tests/make_credential.h
+++ b/src/tests/make_credential.h
@@ -34,9 +34,6 @@ TEST_CLASS(MakeCredentialRelyingPartyEntityTest);
 // Tests bad parameters in user parameter of MakeCredential.
 TEST_CLASS(MakeCredentialUserEntityTest);
 
-// Tests nested CBOR in the exclude list of MakeCredential.
-TEST_CLASS(MakeCredentialExcludeListDepth);
-
 // Tests credential descriptors in the exclude list of MakeCredential.
 TEST_CLASS(MakeCredentialExcludeListCredentialDescriptorTest);
 

--- a/src/tests/test_helpers.h
+++ b/src/tests/test_helpers.h
@@ -84,15 +84,6 @@ std::optional<std::string> TestBadParametersInInnerArray(
     DeviceInterface* device, DeviceTracker* device_tracker, Command command,
     CborBuilder* builder, int outer_map_key, const cbor::Value& array_element);
 
-// Tries to insert a map or an array as a transport in an array of public key
-// credential descriptors. Both excludeList in MakeCredential and allowList in
-// GetAssertion expect this kind of value and share this test. Authenticators
-// must ignore unknown items in the transports list, so unexpected types are
-// untested. For arrays and maps though, the maximum nesting depth is reached.
-std::optional<std::string> TestCredentialDescriptorsArrayForCborDepth(
-    DeviceInterface* device, DeviceTracker* device_tracker, Command command,
-    CborBuilder* builder, int map_key, const std::string& rp_id);
-
 // Returns an optional's string value, if it exists.
 #define NONE_OR_RETURN(x)                             \
   do {                                                \

--- a/src/tests/test_series.cc
+++ b/src/tests/test_series.cc
@@ -34,7 +34,6 @@ const std::vector<std::unique_ptr<BaseTest>>& GetTests() {
     test_list->push_back(
         std::make_unique<MakeCredentialRelyingPartyEntityTest>());
     test_list->push_back(std::make_unique<MakeCredentialUserEntityTest>());
-    test_list->push_back(std::make_unique<MakeCredentialExcludeListDepth>());
     test_list->push_back(
         std::make_unique<MakeCredentialExcludeListCredentialDescriptorTest>());
     test_list->push_back(std::make_unique<MakeCredentialExtensionsTest>());
@@ -64,7 +63,6 @@ const std::vector<std::unique_ptr<BaseTest>>& GetTests() {
 
     test_list->push_back(std::make_unique<GetAssertionBadParameterTypesTest>());
     test_list->push_back(std::make_unique<GetAssertionMissingParameterTest>());
-    test_list->push_back(std::make_unique<GetAssertionAllowListDepthTest>());
     test_list->push_back(
         std::make_unique<GetAssertionAllowListCredentialDescriptorTest>());
     test_list->push_back(std::make_unique<GetAssertionExtensionsTest>());


### PR DESCRIPTION
Removes the tests for CBOR nesting depth.
Fixes #87.