### PR TITLE
adds token to checkout

### DIFF
--- a/.github/workflows/create_summaries.yml
+++ b/.github/workflows/create_summaries.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.SUMMARY_TOKEN }}
     - name: setup python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
Adds the token to `checkout` in the workflow, so it can be used in the subsequent push.
