### PR TITLE
Improved warning on tests that require you NOT to touch

### DIFF
--- a/src/tests/BUILD
+++ b/src/tests/BUILD
@@ -132,6 +132,7 @@ cc_library(
         "//:fido2_commands",
         "//third_party/chromium_components_cbor:cbor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time:time",
         "@com_google_absl//absl/types:variant",
         "@com_google_glog//:glog",
     ],

--- a/src/tests/test_helpers.cc
+++ b/src/tests/test_helpers.cc
@@ -145,7 +145,7 @@ void PrintNoTouchPrompt() {
             << "not touch your security key until the test finishes. You\n"
             << "should see a flashing LED on the device, please ignore it.\n"
             << "===========================================================\n";
-  absl::SleepFor(absl::Milliseconds(2000));
+  absl::SleepFor(absl::Seconds(2));
 }
 
 bool IsFido2Point1Complicant(DeviceTracker* device_tracker) {

--- a/src/tests/test_helpers.cc
+++ b/src/tests/test_helpers.cc
@@ -18,6 +18,8 @@
 #include <iostream>
 
 #include "absl/strings/str_cat.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "absl/types/variant.h"
 #include "glog/logging.h"
 #include "src/cbor_builders.h"
@@ -143,6 +145,7 @@ void PrintNoTouchPrompt() {
             << "not touch your security key until the test finishes. You\n"
             << "should see a flashing LED on the device, please ignore it.\n"
             << "===========================================================\n";
+  absl::SleepFor(absl::Milliseconds(2000));
 }
 
 bool IsFido2Point1Complicant(DeviceTracker* device_tracker) {


### PR DESCRIPTION
Fixes #106

Adds a 2 second delay before continuing the test. This makes it harder to accidentally ignore the warning that the tester should not touch.