### PR TITLE
CTAP2.1 compatible fuzzing crash detector

### DIFF
--- a/src/command_state.cc
+++ b/src/command_state.cc
@@ -105,12 +105,15 @@ absl::variant<cbor::Value, Status> CommandState::MakeTestCredential(
                                                     test_builder.GetCbor());
 }
 
-Status CommandState::ComputeSharedSecret() {
+absl::variant<cbor::Value, Status> CommandState::GetKeyAgreementValue() {
   AuthenticatorClientPinCborBuilder key_agreement_builder;
   key_agreement_builder.AddDefaultsForGetKeyAgreement();
-  absl::variant<cbor::Value, Status> key_response =
-      fido2_commands::AuthenticatorClientPinPositiveTest(
-          device_, device_tracker_, key_agreement_builder.GetCbor());
+  return fido2_commands::AuthenticatorClientPinPositiveTest(
+      device_, device_tracker_, key_agreement_builder.GetCbor());
+}
+
+Status CommandState::ComputeSharedSecret() {
+  absl::variant<cbor::Value, Status> key_response = GetKeyAgreementValue();
   if (absl::holds_alternative<Status>(key_response)) {
     device_tracker_->AddObservation("GetKeyAgreement failed");
     return absl::get<Status>(key_response);

--- a/src/command_state.h
+++ b/src/command_state.h
@@ -45,7 +45,9 @@ class CommandState {
   // Works with or without a PIN being set.
   absl::variant<cbor::Value, Status> MakeTestCredential(std::string rp_id,
                                                         bool use_resident_key);
-  // Compute the shared secret between authenticator and platform. Sets the
+  // Calls the GetKeyAgreement subcommand and returns its result.
+  absl::variant<cbor::Value, Status> GetKeyAgreementValue();
+  // Computes the shared secret between authenticator and platform. Sets the
   // argument platform_cose_key to the EC key used during the transaction.
   Status ComputeSharedSecret();
   // Sets the PIN to the value specified in new_pin_utf8. Performs key agreement

--- a/src/monitors/BUILD
+++ b/src/monitors/BUILD
@@ -48,8 +48,9 @@ cc_library(
     srcs = ["blackbox_monitor.cc"],
     hdrs = ["blackbox_monitor.h"],
     deps = [
-        "//src/monitors:monitor",
         "//:command_state",
+        "//src/monitors:monitor",
+        "//third_party/chromium_components_cbor:cbor",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/src/monitors/blackbox_monitor.h
+++ b/src/monitors/blackbox_monitor.h
@@ -33,7 +33,7 @@ class BlackboxMonitor : public Monitor {
       CommandState* command_state, int retries = 1) override;
 
  private:
-  cbor::Value::BinaryValue initial_pin_token_;
+  cbor::Value initial_key_agreement_;
 };
 
 }  // namespace fido2_tests


### PR DESCRIPTION
As mentioned in #112, our current fuzzing approach does not work for 2.1 compatible devices. This PR fixes the problem that authenticators with 2.1 support always regenerate their PIN tokens on calls to `GetPinToken`. Therefore, detected crashes have always been false positives.

The new approach is to compare the key agreement key, since it is regenerated only on special occasions that are very unlikely to be triggered during fuzzing.

To fully support 2.1 with fuzzing, missing work includes:
- adding new commands,
- regenerating the corpus.