### PR TITLE
Flexible PIN length

### DIFF
--- a/src/command_state.cc
+++ b/src/command_state.cc
@@ -28,6 +28,16 @@ namespace fido2_tests {
 namespace {
 constexpr size_t kPinByteLength = 64;
 constexpr int kResetRetries = 3;
+
+// Returns a PIN of the given length. This PIN is supposed to be used as the
+// default throughout.
+cbor::Value::BinaryValue DefaultPin(size_t pin_length) {
+  cbor::Value::BinaryValue pin;
+  for (size_t i = 0; i < pin_length; ++i) {
+    pin.push_back('1' + i);
+  }
+  return pin;
+}
 }  // namespace
 
 CommandState::CommandState(DeviceInterface* device,
@@ -158,6 +168,10 @@ Status CommandState::SetPin(const cbor::Value::BinaryValue& new_pin_utf8) {
   }
 }
 
+Status CommandState::SetPin() {
+  return SetPin(DefaultPin(device_tracker_->GetMinPinLength()));
+}
+
 Status CommandState::AttemptSetPin(
     const cbor::Value::BinaryValue& new_padded_pin) {
   if (platform_cose_key_.empty() || shared_secret_.empty()) {
@@ -282,6 +296,10 @@ Status CommandState::AttemptGetAuthToken(
     OK_OR_RETURN(ComputeSharedSecret());
   }
   return returned_status;
+}
+
+Status CommandState::AttemptGetAuthToken() {
+  return AttemptGetAuthToken(DefaultPin(device_tracker_->GetMinPinLength()));
 }
 
 cbor::Value::BinaryValue CommandState::GetCurrentAuthToken() {

--- a/src/command_state.h
+++ b/src/command_state.h
@@ -52,8 +52,9 @@ class CommandState {
   // if not already done. Safe to call multiple times, and only talks to the
   // authenticator if there is no PIN already. Defaults to 1234 if nothing else
   // is set. Fails if the PIN requirements are not satisfied.
-  Status SetPin(const cbor::Value::BinaryValue& new_pin_utf8 = {0x31, 0x32,
-                                                                0x33, 0x34});
+  Status SetPin(const cbor::Value::BinaryValue& new_pin_utf8);
+  // Sets the PIN as above, using a default.
+  Status SetPin();
   // Calls the SetPin command with the given padded PIN. Fails if the length is
   // not a multiple of the AES block size. Returns the command's status code.
   // Performs key agreement if not already done.
@@ -66,7 +67,7 @@ class CommandState {
   // Returns the command's status code. Creates a PIN if not already done.
   Status AttemptChangePin(const cbor::Value::BinaryValue& new_padded_pin);
   // Returns a PIN Auth token valid for this power cycle from the authenticator.
-  // Sets the PIN to 1234 if no PIN exists and set_pin_if_necessary is true.
+  // Defaults the PIN if none exists and set_pin_if_necessary is true.
   Status GetAuthToken(bool set_pin_if_necessary = true);
   // Calls the GetAuthToken command with the given PIN. Creates a PIN if
   // not already done. The tested PIN defaults to 1234, which should work with
@@ -75,9 +76,11 @@ class CommandState {
   // necessary because authenticators reset the key agreement on failed PIN
   // hash checks. Setting redo_key_agreement is only used for specific failure
   // mode tests.
-  Status AttemptGetAuthToken(
-      const cbor::Value::BinaryValue& pin_utf8 = {0x31, 0x32, 0x33, 0x34},
-      bool redo_key_agreement = true);
+  Status AttemptGetAuthToken(const cbor::Value::BinaryValue& pin_utf8,
+                             bool redo_key_agreement = true);
+  // Attemps to call GetAuthToken as above, using a default PIN and redoing the
+  // key agreements afterwards.
+  Status AttemptGetAuthToken();
   // Returns the currently stored auth token. This value represents what should
   // be the internal state of the device right now (or is empty if unknown).
   cbor::Value::BinaryValue GetCurrentAuthToken();

--- a/src/device_tracker.cc
+++ b/src/device_tracker.cc
@@ -81,6 +81,8 @@ void DeviceTracker::Initialize(const cbor::Value::MapValue& info_map) {
   is_initialized_ = true;
 
   auto map_iter = info_map.find(CborValue(InfoMember::kVersions));
+  CHECK(map_iter != info_map.end())
+      << "no versions in GetInfo response - TEST SUITE BUG";
   const cbor::Value::ArrayValue& versions = map_iter->second.GetArray();
   for (const auto& versions_iter : versions) {
     if (versions_iter.is_string()) {

--- a/src/device_tracker.cc
+++ b/src/device_tracker.cc
@@ -74,26 +74,34 @@ nlohmann::json TestResult::ToJson() const {
 DeviceTracker::DeviceTracker()
     : key_checker_(std::vector<std::vector<uint8_t>>()) {}
 
-void DeviceTracker::Initialize(const cbor::Value::ArrayValue& versions,
-                               const cbor::Value::ArrayValue& extensions,
-                               const cbor::Value::MapValue& options) {
+void DeviceTracker::Initialize(const cbor::Value::MapValue& info_map) {
   if (is_initialized_) {
     return;
   }
   is_initialized_ = true;
 
+  auto map_iter = info_map.find(CborValue(InfoMember::kVersions));
+  const cbor::Value::ArrayValue& versions = map_iter->second.GetArray();
   for (const auto& versions_iter : versions) {
     if (versions_iter.is_string()) {
       versions_.insert(versions_iter.GetString());
     }
   }
 
-  for (const auto& extensions_iter : extensions) {
-    if (extensions_iter.is_string()) {
-      extensions_.insert(extensions_iter.GetString());
+  map_iter = info_map.find(CborValue(InfoMember::kExtensions));
+  if (map_iter != info_map.end()) {
+    const cbor::Value::ArrayValue& extensions = map_iter->second.GetArray();
+    for (const auto& extensions_iter : extensions) {
+      if (extensions_iter.is_string()) {
+        extensions_.insert(extensions_iter.GetString());
+      }
     }
   }
 
+  map_iter = info_map.find(CborValue(InfoMember::kOptions));
+  cbor::Value::MapValue empty_options;
+  const cbor::Value::MapValue& options =
+      map_iter != info_map.end() ? map_iter->second.GetMap() : empty_options;
   absl::flat_hash_set<std::string> mutable_options = {"clientPin", "uv",
                                                       "bioEnroll"};
   for (const auto& options_iter : options) {
@@ -113,6 +121,11 @@ void DeviceTracker::Initialize(const cbor::Value::ArrayValue& versions,
       options_.insert(option);
     }
   }
+
+  map_iter = info_map.find(CborValue(InfoMember::kMinPinLength));
+  if (map_iter != info_map.end()) {
+    min_pin_length_ = map_iter->second.GetUnsigned();
+  }
 }
 
 bool DeviceTracker::HasVersion(std::string_view version_name) const {
@@ -126,6 +139,8 @@ bool DeviceTracker::HasExtension(std::string_view extension_name) const {
 bool DeviceTracker::HasOption(std::string_view option_name) const {
   return options_.contains(option_name);
 }
+
+size_t DeviceTracker::GetMinPinLength() const { return min_pin_length_; }
 
 bool DeviceTracker::HasWinkCapability() const { return has_wink_capability_; }
 

--- a/src/device_tracker.h
+++ b/src/device_tracker.h
@@ -49,7 +49,7 @@ class DeviceTracker {
   // is not available until calling Initialize. You can always log findings.
   DeviceTracker();
   // Writes information about device capabilities. Call this function during a
-  // GetInfo call.
+  // GetInfo call. The passed in info_map must be a valid GetInfo response.
   void Initialize(const cbor::Value::MapValue& info_map);
   // Returns if the device supports the version. Will always return false if not
   // initialized.

--- a/src/device_tracker.h
+++ b/src/device_tracker.h
@@ -50,9 +50,7 @@ class DeviceTracker {
   DeviceTracker();
   // Writes information about device capabilities. Call this function during a
   // GetInfo call.
-  void Initialize(const cbor::Value::ArrayValue& versions,
-                  const cbor::Value::ArrayValue& extensions,
-                  const cbor::Value::MapValue& options);
+  void Initialize(const cbor::Value::MapValue& info_map);
   // Returns if the device supports the version. Will always return false if not
   // initialized.
   bool HasVersion(std::string_view version_name) const;
@@ -62,6 +60,8 @@ class DeviceTracker {
   // Returns if the device supports the option. Will always return false if not
   // initialized.
   bool HasOption(std::string_view option_name) const;
+  // Returns the minimum PIN length as advertized in GetInfo.
+  size_t GetMinPinLength() const;
   // Returns if the device sets the wink capability in its response to Init.
   // Must be set through SetCapabilities, or returns false.
   bool HasWinkCapability() const;
@@ -127,10 +127,8 @@ class DeviceTracker {
   DeviceIdentifiers device_identifiers_;
   std::string aaguid_;
   bool ignores_touch_prompt_ = false;
-  // We want the observations, problems and tests to be listed in order of
-  // appearance.
+  // We want the observations and tests to be listed in order of appearance.
   std::vector<std::string> observations_;
-  std::vector<std::string> problems_;
   std::vector<TestResult> tests_;
   absl::flat_hash_set<std::string> versions_;
   absl::flat_hash_set<std::string> extensions_;
@@ -138,6 +136,7 @@ class DeviceTracker {
   // We only care about being supported in general, and activate as necessary.
   // Also, options that default to true are always initialized.
   absl::flat_hash_set<std::string> options_;
+  size_t min_pin_length_ = 4;
   bool is_initialized_ = false;
   bool has_wink_capability_ = false;
   bool has_cbor_capability_ = false;

--- a/src/device_tracker_test.cc
+++ b/src/device_tracker_test.cc
@@ -33,8 +33,12 @@ TEST(DeviceTracker, TestInitialize) {
   options[cbor::Value("rk")] = cbor::Value(true);
   options[cbor::Value("clientPin")] = cbor::Value(false);
   options[cbor::Value("bioEnroll")] = cbor::Value(true);
+  cbor::Value::MapValue info;
+  info[CborValue(InfoMember::kVersions)] = cbor::Value(versions);
+  info[CborValue(InfoMember::kExtensions)] = cbor::Value(extensions);
+  info[CborValue(InfoMember::kOptions)] = cbor::Value(options);
 
-  device_tracker.Initialize(versions, extensions, options);
+  device_tracker.Initialize(info);
   EXPECT_TRUE(device_tracker.HasVersion("VERSION"));
   EXPECT_FALSE(device_tracker.HasVersion("WRONG_VERSION"));
   EXPECT_TRUE(device_tracker.HasExtension("EXTENSION"));
@@ -48,11 +52,23 @@ TEST(DeviceTracker, TestInitialize) {
 TEST(DeviceTracker, TestInitializeDefault) {
   DeviceTracker device_tracker = DeviceTracker();
   cbor::Value::ArrayValue versions;
-  cbor::Value::ArrayValue extensions;
-  cbor::Value::MapValue options;
+  cbor::Value::MapValue info;
+  info[CborValue(InfoMember::kVersions)] = cbor::Value(versions);
 
-  device_tracker.Initialize(versions, extensions, options);
+  device_tracker.Initialize(info);
   EXPECT_TRUE(device_tracker.HasOption("up"));
+}
+
+TEST(DeviceTracker, TestGetMinPinLength) {
+  DeviceTracker device_tracker = DeviceTracker();
+  EXPECT_EQ(device_tracker.GetMinPinLength(), 4);
+
+  cbor::Value::ArrayValue versions;
+  cbor::Value::MapValue info;
+  info[CborValue(InfoMember::kVersions)] = cbor::Value(versions);
+  info[CborValue(InfoMember::kMinPinLength)] = cbor::Value(6);
+  device_tracker.Initialize(info);
+  EXPECT_EQ(device_tracker.GetMinPinLength(), 6);
 }
 
 TEST(DeviceTracker, TestCheckStatusOneArgument) {
@@ -89,8 +105,12 @@ TEST(DeviceTracker, TestGenerateResultsJson) {
   extensions.push_back(cbor::Value("EXTENSION"));
   cbor::Value::MapValue options;
   options[cbor::Value("up")] = cbor::Value(true);
+  cbor::Value::MapValue info;
+  info[CborValue(InfoMember::kVersions)] = cbor::Value(versions);
+  info[CborValue(InfoMember::kExtensions)] = cbor::Value(extensions);
+  info[CborValue(InfoMember::kOptions)] = cbor::Value(options);
 
-  device_tracker.Initialize(versions, extensions, options);
+  device_tracker.Initialize(info);
   device_tracker.SetDeviceIdentifiers({.manufacturer = "M",
                                        .product_name = "P",
                                        .serial_number = "S",

--- a/src/fido2_commands.cc
+++ b/src/fido2_commands.cc
@@ -490,7 +490,6 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
   }
   CHECK(versions_set.find("FIDO_2_0") != versions_set.end())
       << "versions does not contain \"FIDO_2_0\"";
-  const cbor::Value::ArrayValue& versions = map_iter->second.GetArray();
 
   map_iter = decoded_map.find(CborValue(InfoMember::kExtensions));
   if (map_iter != decoded_map.end()) {
@@ -503,10 +502,6 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
       extensions_set.insert(extension.GetString());
     }
   }
-  cbor::Value::ArrayValue empty_extensions;
-  const cbor::Value::ArrayValue& extensions = map_iter != decoded_map.end()
-                                                  ? map_iter->second.GetArray()
-                                                  : empty_extensions;
 
   map_iter = decoded_map.find(CborValue(InfoMember::kAaguid));
   CHECK(map_iter != decoded_map.end())
@@ -521,9 +516,6 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
       CHECK(options_iter.second.is_bool()) << "option value is not a boolean";
     }
   }
-  cbor::Value::MapValue empty_options;
-  const cbor::Value::MapValue& options =
-      map_iter != decoded_map.end() ? map_iter->second.GetMap() : empty_options;
 
   map_iter = decoded_map.find(CborValue(InfoMember::kMaxMsgSize));
   if (map_iter != decoded_map.end()) {
@@ -682,7 +674,7 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
     }
   }
 
-  device_tracker->Initialize(versions, extensions, options);
+  device_tracker->Initialize(decoded_map);
   return decoded_response->Clone();
 }
 

--- a/src/tests/BUILD
+++ b/src/tests/BUILD
@@ -138,3 +138,12 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "test_helpers_test",
+    srcs = ["test_helpers_test.cc"],
+    deps = [
+        ":test_helpers",
+        "@com_google_googletest//:gtest_main",
+    ],
+    size = "small",
+)

--- a/src/tests/client_pin.cc
+++ b/src/tests/client_pin.cc
@@ -447,8 +447,8 @@ std::optional<std::string> ClientPinOldKeyMaterialTest::Execute(
     DeviceInterface* device, DeviceTracker* device_tracker,
     CommandState* command_state) const {
   // Reuses key material that should have been renewed to see if it still works.
-  Status returned_status =
-      command_state->AttemptGetAuthToken(test_helpers::BadPin(), false);
+  Status returned_status = command_state->AttemptGetAuthToken(
+      test_helpers::BadPin(device_tracker->GetMinPinLength()), false);
   if (!device_tracker->CheckStatus(Status::kErrPinInvalid, returned_status)) {
     return "A wrong PIN was not rejected.";
   }
@@ -491,8 +491,8 @@ std::optional<std::string> ClientPinGeneralPinRetriesTest::Execute(
     return "PIN retries changed between subsequent calls.";
   }
 
-  Status returned_status =
-      command_state->AttemptGetAuthToken(test_helpers::BadPin());
+  Status returned_status = command_state->AttemptGetAuthToken(
+      test_helpers::BadPin(device_tracker->GetMinPinLength()));
   if (!device_tracker->CheckStatus(Status::kErrPinInvalid, returned_status)) {
     return "A wrong PIN was not rejected.";
   }
@@ -543,14 +543,14 @@ std::optional<std::string> ClientPinAuthBlockPinRetriesTest::Execute(
   }
 
   for (int attempts = 1; attempts < kWrongPinsBeforePowerCycle; ++attempts) {
-    Status returned_status =
-        command_state->AttemptGetAuthToken(test_helpers::BadPin());
+    Status returned_status = command_state->AttemptGetAuthToken(
+        test_helpers::BadPin(device_tracker->GetMinPinLength()));
     if (!device_tracker->CheckStatus(Status::kErrPinInvalid, returned_status)) {
       return "A wrong PIN was not rejected.";
     }
   }
-  Status returned_status =
-      command_state->AttemptGetAuthToken(test_helpers::BadPin());
+  Status returned_status = command_state->AttemptGetAuthToken(
+      test_helpers::BadPin(device_tracker->GetMinPinLength()));
   if (!device_tracker->CheckStatus(Status::kErrPinAuthBlocked,
                                    returned_status)) {
     return "A wrong PIN was not blocked.";
@@ -611,8 +611,8 @@ std::optional<std::string> ClientPinBlockPinRetriesTest::Execute(
 
   // Leaves one attempt.
   for (int attempts = 1; attempts < max_retries; ++attempts) {
-    Status returned_status =
-        command_state->AttemptGetAuthToken(test_helpers::BadPin());
+    Status returned_status = command_state->AttemptGetAuthToken(
+        test_helpers::BadPin(device_tracker->GetMinPinLength()));
     if (attempts % kWrongPinsBeforePowerCycle != 0) {
       // Normal case, PIN not blocked.
       if (!device_tracker->CheckStatus(Status::kErrPinInvalid,
@@ -636,8 +636,8 @@ std::optional<std::string> ClientPinBlockPinRetriesTest::Execute(
     }
   }
 
-  Status returned_status =
-      command_state->AttemptGetAuthToken(test_helpers::BadPin());
+  Status returned_status = command_state->AttemptGetAuthToken(
+      test_helpers::BadPin(device_tracker->GetMinPinLength()));
   if (!device_tracker->CheckStatus(Status::kErrPinBlocked, returned_status)) {
     return "The PIN is not blocked after the counter reached 0.";
   }

--- a/src/tests/general.cc
+++ b/src/tests/general.cc
@@ -117,7 +117,8 @@ std::optional<std::string> PersistentPinRetriesTest::Execute(
     CommandState* command_state) const {
   if (!device_tracker->CheckStatus(
           Status::kErrPinInvalid,
-          command_state->AttemptGetAuthToken(test_helpers::BadPin()))) {
+          command_state->AttemptGetAuthToken(
+              test_helpers::BadPin(device_tracker->GetMinPinLength())))) {
     return "GetAuthToken did not fail with the wrong PIN.";
   }
   auto reduced_counter = test_helpers::GetPinRetries(device, device_tracker);

--- a/src/tests/reset.cc
+++ b/src/tests/reset.cc
@@ -95,7 +95,8 @@ std::optional<std::string> DeletePinTest::Execute(
   }
   if (!device_tracker->CheckStatus(
           Status::kErrPinInvalid,
-          command_state->AttemptGetAuthToken(test_helpers::BadPin()))) {
+          command_state->AttemptGetAuthToken(
+              test_helpers::BadPin(device_tracker->GetMinPinLength())))) {
     return "GetAuthToken did not fail with the wrong PIN.";
   }
   cbor::Value::BinaryValue old_auth_token =

--- a/src/tests/test_helpers.cc
+++ b/src/tests/test_helpers.cc
@@ -107,7 +107,9 @@ int ExtractPinRetries(const cbor::Value& response) {
 
 namespace test_helpers {
 
-cbor::Value::BinaryValue BadPin() { return {0x66, 0x61, 0x6B, 0x65}; }
+cbor::Value::BinaryValue BadPin(size_t pin_length) {
+  return cbor::Value::BinaryValue(pin_length, '$');
+}
 
 // Extracts the credential ID from an authenticator data structure[1].
 // [1] https://www.w3.org/TR/webauthn/#sec-authenticator-data

--- a/src/tests/test_helpers.h
+++ b/src/tests/test_helpers.h
@@ -25,9 +25,10 @@ namespace fido2_tests {
 
 namespace test_helpers {
 
-// Returns a PIN that is different from the PIN set on the device. This is
-// enforced in SetPin() by making sure the chosen PIN is different.
-cbor::Value::BinaryValue BadPin();
+// Returns a PIN of the given length. It is similar to DefaultPin in
+// command_state.cc, but differs in suggested usage. The bad PIN is never
+// supposed to be successfully set as the device PIN.
+cbor::Value::BinaryValue BadPin(size_t pin_length);
 
 // Extracts the credential ID from an authenticator data structure[1].
 // [1] https://www.w3.org/TR/webauthn/#sec-authenticator-data

--- a/src/tests/test_helpers_test.cc
+++ b/src/tests/test_helpers_test.cc
@@ -1,0 +1,32 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/tests/test_helpers.h"
+
+#include "gtest/gtest.h"
+
+namespace fido2_tests {
+namespace {
+
+TEST(TestHelpers, TestBadPin) {
+  std::vector<uint8_t> pin = {'$', '$', '$', '$'};
+  EXPECT_EQ(test_helpers::BadPin(4), pin);
+
+  pin = {'$', '$', '$', '$', '$', '$'};
+  EXPECT_EQ(test_helpers::BadPin(6), pin);
+}
+
+}  // namespace
+}  // namespace fido2_tests
+


### PR DESCRIPTION
Fixes #102.

The minimum PIN length is read in `GetInfo` and then used to generate a default PIN that works for the given minimum length. Anticipating more information from `GetInfo` to be useful for the `DeviceTracker` class, its `Initilization` now gets all information passed in.