### PR TITLE
Constants for new commands

### DIFF
--- a/src/constants.cc
+++ b/src/constants.cc
@@ -125,6 +125,16 @@ std::string CommandToString(Command command) {
       return "reset command";
     case Command::kAuthenticatorGetNextAssertion:
       return "get next assertion command";
+    case Command::kAuthenticatorBioEnrollment:
+      return "bio enrollment command";
+    case Command::kAuthenticatorCredentialManagement:
+      return "credential management command";
+    case Command::kAuthenticatorSelection:
+      return "selection command";
+    case Command::kAuthenticatorLargeBlobs:
+      return "large blobs command";
+    case Command::kAuthenticatorConfig:
+      return "config command";
     default:
       CHECK(false) << "unreachable default - TEST SUITE BUG";
   }
@@ -158,6 +168,28 @@ cbor::Value CborValue(ClientPinResponse response) {
 
 bool ClientPinResponseContains(int64_t key) {
   return key >= 0x01 && key <= 0x05;
+}
+
+cbor::Value CborValue(CredentialManagementResponse response) {
+  return cbor::Value(static_cast<uint8_t>(response));
+}
+
+bool CredentialManagementResponseContains(int64_t key) {
+  return key >= 0x01 && key <= 0x0B;
+}
+
+cbor::Value CborValue(LargeBlobsResponse response) {
+  return cbor::Value(static_cast<uint8_t>(response));
+}
+
+bool LargeBlobsResponseContains(int64_t key) { return key == 0x01; }
+
+cbor::Value CborValue(BioEnrollmentResponse response) {
+  return cbor::Value(static_cast<uint8_t>(response));
+}
+
+bool BioEnrollmentResponseContains(int64_t key) {
+  return key >= 0x01 && key <= 0x08;
 }
 
 }  // namespace fido2_tests

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -104,6 +104,8 @@ std::string StatusToString(Status status) {
       return "CTAP2_ERR_UP_REQUIRED";
     case Status::kErrUvBlocked:
       return "CTAP2_ERR_UV_BLOCKED";
+    case Status::kErrTestToolInternal:
+      return "TEST TOOL FOUND A PROBLEM";
     case Status::kErrOther:
       return "CTAP1_ERR_OTHER";
     default:

--- a/src/constants.h
+++ b/src/constants.h
@@ -88,7 +88,12 @@ enum class Command : uint8_t {
   kAuthenticatorGetInfo = 0x04,
   kAuthenticatorClientPIN = 0x06,
   kAuthenticatorReset = 0x07,
-  kAuthenticatorGetNextAssertion = 0x08
+  kAuthenticatorGetNextAssertion = 0x08,
+  kAuthenticatorBioEnrollment = 0x09,
+  kAuthenticatorCredentialManagement = 0x0A,
+  kAuthenticatorSelection = 0x0B,
+  kAuthenticatorLargeBlobs = 0x0C,
+  kAuthenticatorConfig = 0x0D,
 };
 
 // Converts a Command to a string for printing.
@@ -101,7 +106,7 @@ enum class Algorithm {
   kRs256Algorithm = -257
 };
 
-// The reset command has a few sub commands with the following representations.
+// The ClientPin command has these sub commands.
 enum class PinSubCommand : uint8_t {
   kGetPinRetries = 0x01,
   kGetKeyAgreement = 0x02,
@@ -109,7 +114,8 @@ enum class PinSubCommand : uint8_t {
   kChangePin = 0x04,
   kGetPinToken = 0x05,
   kGetPinUvAuthTokenUsingUvWithPermissions = 0x06,
-  kGetUvRetries = 0x07
+  kGetUvRetries = 0x07,
+  kGetPinUvAuthTokenUsingPinWithPermissions = 0x09,
 };
 
 // A keepalive packet has two possible status bytes, or errors.
@@ -233,6 +239,143 @@ cbor::Value CborValue(ClientPinResponse response);
 
 // Checks if the key is used in this enum.
 bool ClientPinResponseContains(int64_t key);
+
+// The command CredentialManagement has a parameter map with the following keys.
+enum class CredentialManagementParameters : uint8_t {
+  kSubCommand = 0x01,
+  kSubCommandParams = 0x02,
+  kPinUvAuthProtocol = 0x03,
+  kPinUvAuthParam = 0x04,
+};
+
+// Contains the map keys for CredentialManagement responses.
+enum class CredentialManagementResponse : uint8_t {
+  kExistingResidentCredentialsCount = 0x01,
+  kMaxPossibleRemainingResidentCredentialsCount = 0x02,
+  kRp = 0x03,
+  kRpIdHash = 0x04,
+  kTotalRps = 0x05,
+  kUser = 0x06,
+  kCredentialId = 0x07,
+  kPublicKey = 0x08,
+  kTotalCredentials = 0x09,
+  kCredProtect = 0x0A,
+  kLargeBlobKey = 0x0B,
+};
+
+// Converts a CredentialManagement response key to a cbor::Value.
+cbor::Value CborValue(CredentialManagementResponse response);
+
+// Checks if the key is used in this enum.
+bool CredentialManagementResponseContains(int64_t key);
+
+// The CredentialManagement command has these sub commands.
+enum class ManagementSubCommand : uint8_t {
+  kGetCredsMetadata = 0x01,
+  kEnumerateRpsBegin = 0x02,
+  kEnumerateRpsGetNextRp = 0x03,
+  kEnumerateCredentialsBegin = 0x04,
+  kEnumerateCredentialsGetNextCredential = 0x05,
+  kDeleteCredential = 0x06,
+  kUpdateUserInformation = 0x07,
+};
+
+// The CredentialManagement sub commands have these parameters.
+enum class ManagementSubCommandParams : uint8_t {
+  kRpIdHash = 0x01,
+  kCredentialId = 0x02,
+  kUser = 0x03,
+};
+
+// The command BioEnrollment has a parameter map with the following keys.
+enum class BioEnrollmentParameters : uint8_t {
+  kModality = 0x01,
+  kSubCommand = 0x02,
+  kSubCommandParams = 0x03,
+  kPinUvAuthProtocol = 0x04,
+  kPinUvAuthParam = 0x05,
+  kGetModality = 0x06,
+};
+
+// Contains the map keys for BioEnrollment responses.
+enum class BioEnrollmentResponse : uint8_t {
+  kModality = 0x01,
+  kFingerprintKind = 0x02,
+  kMaxCaptureSamplesRequiredForEnroll = 0x03,
+  kTemplateId = 0x04,
+  kLastEnrollSampleStatus = 0x05,
+  kRemainingSamples = 0x06,
+  kTemplateInfos = 0x07,
+  kMaxTemplateFriendlyName = 0x08,
+};
+
+// Converts a BioEnrollment response key to a cbor::Value.
+cbor::Value CborValue(BioEnrollmentResponse response);
+
+// Checks if the key is used in this enum.
+bool BioEnrollmentResponseContains(int64_t key);
+
+// The BioEnrollment command has these sub commands.
+enum class BioEnrollmentSubCommand : uint8_t {
+  kEnrollBegin = 0x01,
+  kEnrollCaptureNextSample = 0x02,
+  kCancelCurrentEnrollment = 0x03,
+  kEnumerateEnrollments = 0x04,
+  kSetFriendlyName = 0x05,
+  kRemoveEnrollment = 0x06,
+  kGetFingerprintSensorInfo = 0x07,
+};
+
+// The BioEnrollment sub commands have these parameters.
+enum class BioEnrollmentSubCommandParams : uint8_t {
+  kTemplateId = 0x01,
+  kTemplateFriendlyName = 0x02,
+  kTimeoutMilliseconds = 0x03,
+};
+
+// The command LargeBlobs has a parameter map with the following keys.
+enum class LargeBlobsParameters : uint8_t {
+  kGet = 0x01,
+  kSet = 0x02,
+  kOffset = 0x03,
+  kLength = 0x04,
+  kPinUvAuthParam = 0x05,
+  kPinUvAuthProtocol = 0x06,
+};
+
+// Contains the map keys for LargeBlobs responses.
+enum class LargeBlobsResponse : uint8_t {
+  kConfig = 0x01,
+};
+
+// Converts a LargeBlobs response key to a cbor::Value.
+cbor::Value CborValue(LargeBlobsResponse response);
+
+// Checks if the key is used in this enum.
+bool LargeBlobsResponseContains(int64_t key);
+
+// The command Config has a parameter map with the following keys.
+enum class ConfigParameters : uint8_t {
+  kSubCommand = 0x01,
+  kSubCommandParams = 0x02,
+  kPinUvAuthProtocol = 0x03,
+  kPinUvAuthParam = 0x04,
+};
+
+// The Config command has these sub commands.
+enum class ConfigSubCommand : uint8_t {
+  kEnableEnterpriseAttestation = 0x01,
+  kToggleAlwaysUv = 0x02,
+  kSetMinPinLength = 0x03,
+  kVendorPrototype = 0x04,
+};
+
+// The Configsub commands have these parameters.
+enum class ConfigSubCommandParams : uint8_t {
+  kNewMinPinLength = 0x01,
+  kMinPinLengthRpIds = 0x02,
+  kForceChangePin = 0x03,
+};
 
 }  // namespace fido2_tests
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -66,6 +66,7 @@ enum class Status : uint8_t {
   kErrActionTimeout = 0x3A,
   kErrUpRequired = 0x3B,
   kErrUvBlocked = 0x3C,
+  kErrTestToolInternal = 0x7E,
   kErrOther = 0x7F
 };
 
@@ -115,6 +116,7 @@ enum class PinSubCommand : uint8_t {
   kGetPinToken = 0x05,
   kGetPinUvAuthTokenUsingUvWithPermissions = 0x06,
   kGetUvRetries = 0x07,
+  // Sub command 0x08 existed in a draft, but was removed.
   kGetPinUvAuthTokenUsingPinWithPermissions = 0x09,
 };
 

--- a/src/fido2_commands.cc
+++ b/src/fido2_commands.cc
@@ -778,6 +778,16 @@ absl::variant<cbor::Value, Status> AuthenticatorClientPinPositiveTest(
           << "UV retries entry is not an unsigned";
       break;
     }
+    case PinSubCommand::kGetPinUvAuthTokenUsingPinWithPermissions: {
+      allowed_map_keys.insert(ClientPinResponse::kPinUvAuthToken);
+      auto map_iter =
+          decoded_map.find(CborValue(ClientPinResponse::kPinUvAuthToken));
+      CHECK(map_iter != decoded_map.end())
+          << "no pinUvAuthToken (key 2) in PIN protocol response";
+      CHECK(map_iter->second.is_bytestring())
+          << "pinUvAuthToken entry is not a bytestring";
+      break;
+    }
   }
 
   // Check for unexpected map keys.

--- a/src/fido2_commands.cc
+++ b/src/fido2_commands.cc
@@ -788,6 +788,10 @@ absl::variant<cbor::Value, Status> AuthenticatorClientPinPositiveTest(
           << "pinUvAuthToken entry is not a bytestring";
       break;
     }
+    default:
+      device_tracker->AddObservation(
+          "ClientPin was called with an unknown sub command.");
+      return Status::kErrTestToolInternal;
   }
 
   // Check for unexpected map keys.


### PR DESCRIPTION
Adds the keys for parameters, responses and subcommands for `AuthenticatorCredentialManagement`, `AuthenticatorBioEnrollment`, `AuthenticatorLargeBlobs` and `AuthenticatorConfig`.

The least boring part of this PR is the extra sub command for `ClientPin`, that is checked in `fido_commands.cc`. As `GetPinUvAuthTokenUsingPinWithPermissions` returns the same map as `GetPinToken`, it is just a copy of that check. So still not too exciting. :)