### PR TITLE
Better constants conversion

### DIFF
--- a/src/command_state.cc
+++ b/src/command_state.cc
@@ -49,7 +49,7 @@ CommandState::CommandState(DeviceInterface* device,
   device_tracker_->AssertResponse(response, "GetInfo");
 
   const auto& decoded_map = absl::get<cbor::Value>(response).GetMap();
-  if (auto map_iter = decoded_map.find(CborValue(InfoMember::kAaguid));
+  if (auto map_iter = decoded_map.find(CborInt(InfoMember::kAaguid));
       map_iter != decoded_map.end()) {
     const cbor::Value::BinaryValue& aaguid_bytes =
         map_iter->second.GetBytestring();
@@ -131,7 +131,7 @@ Status CommandState::ComputeSharedSecret() {
 
   const auto& key_agreement_map = absl::get<cbor::Value>(key_response).GetMap();
   auto map_iter =
-      key_agreement_map.find(CborValue(ClientPinResponse::kKeyAgreement));
+      key_agreement_map.find(CborInt(ClientPinResponse::kKeyAgreement));
   shared_secret_ = crypto_utility::CompleteEcdhHandshake(
       map_iter->second.GetMap(), &platform_cose_key_);
   return Status::kErrNone;
@@ -276,7 +276,7 @@ Status CommandState::GetAuthToken(bool set_pin_if_necessary) {
     const auto& pin_token_map =
         absl::get<cbor::Value>(pin_token_response).GetMap();
     auto map_iter =
-        pin_token_map.find(CborValue(ClientPinResponse::kPinUvAuthToken));
+        pin_token_map.find(CborInt(ClientPinResponse::kPinUvAuthToken));
     cbor::Value::BinaryValue encrypted_token = map_iter->second.GetBytestring();
     auth_token_ =
         crypto_utility::Aes256CbcDecrypt(shared_secret_, encrypted_token);

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -142,7 +142,7 @@ std::string CommandToString(Command command) {
   }
 }
 
-cbor::Value CborValue(Algorithm alg) {
+cbor::Value CborInt(Algorithm alg) {
   return cbor::Value(static_cast<int>(alg));
 }
 

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -142,53 +142,29 @@ std::string CommandToString(Command command) {
   }
 }
 
-cbor::Value CborValue(MakeCredentialResponse response) {
-  return cbor::Value(static_cast<uint8_t>(response));
+cbor::Value CborValue(Algorithm alg) {
+  return cbor::Value(static_cast<int>(alg));
 }
 
 bool MakeCredentialResponseContains(int64_t key) {
   return key >= 0x01 && key <= 0x05;
 }
 
-cbor::Value CborValue(GetAssertionResponse response) {
-  return cbor::Value(static_cast<uint8_t>(response));
-}
-
 bool GetAssertionResponseContains(int64_t key) {
   return key >= 0x01 && key <= 0x07;
 }
 
-cbor::Value CborValue(InfoMember response) {
-  return cbor::Value(static_cast<uint8_t>(response));
-}
-
 bool InfoMemberContains(int64_t key) { return key >= 0x01 && key <= 0x15; }
-
-cbor::Value CborValue(ClientPinResponse response) {
-  return cbor::Value(static_cast<uint8_t>(response));
-}
 
 bool ClientPinResponseContains(int64_t key) {
   return key >= 0x01 && key <= 0x05;
-}
-
-cbor::Value CborValue(CredentialManagementResponse response) {
-  return cbor::Value(static_cast<uint8_t>(response));
 }
 
 bool CredentialManagementResponseContains(int64_t key) {
   return key >= 0x01 && key <= 0x0B;
 }
 
-cbor::Value CborValue(LargeBlobsResponse response) {
-  return cbor::Value(static_cast<uint8_t>(response));
-}
-
 bool LargeBlobsResponseContains(int64_t key) { return key == 0x01; }
-
-cbor::Value CborValue(BioEnrollmentResponse response) {
-  return cbor::Value(static_cast<uint8_t>(response));
-}
 
 bool BioEnrollmentResponseContains(int64_t key) {
   return key >= 0x01 && key <= 0x08;

--- a/src/constants.h
+++ b/src/constants.h
@@ -108,11 +108,11 @@ enum class Algorithm {
 };
 
 // Converts a the algorithm to a cbor::Value.
-cbor::Value CborValue(Algorithm alg);
+cbor::Value CborInt(Algorithm alg);
 
 // Converts parameter, response and subcommand keys to cbor::Value.
 template <typename T>
-cbor::Value CborValue(T variant) {
+cbor::Value CborInt(T variant) {
   return cbor::Value(static_cast<uint8_t>(variant));
 }
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -107,6 +107,15 @@ enum class Algorithm {
   kRs256Algorithm = -257
 };
 
+// Converts a the algorithm to a cbor::Value.
+cbor::Value CborValue(Algorithm alg);
+
+// Converts parameter, response and subcommand keys to cbor::Value.
+template <typename T>
+cbor::Value CborValue(T variant) {
+  return cbor::Value(static_cast<uint8_t>(variant));
+}
+
 // The ClientPin command has these sub commands.
 enum class PinSubCommand : uint8_t {
   kGetPinRetries = 0x01,
@@ -173,9 +182,6 @@ enum class MakeCredentialResponse : uint8_t {
   kLargeBlobKey = 0x05,
 };
 
-// Converts a MakeCredential response key to a cbor::Value.
-cbor::Value CborValue(MakeCredentialResponse response);
-
 // Checks if the key is used in this enum.
 bool MakeCredentialResponseContains(int64_t key);
 
@@ -189,9 +195,6 @@ enum class GetAssertionResponse : uint8_t {
   kUserSelected = 0x06,
   kLargeBlobKey = 0x07,
 };
-
-// Converts a GetAssertion response key to a cbor::Value.
-cbor::Value CborValue(GetAssertionResponse response);
 
 // Checks if the key is used in this enum.
 bool GetAssertionResponseContains(int64_t key);
@@ -221,9 +224,6 @@ enum class InfoMember : uint8_t {
   kVendorPrototypeConfigCommands = 0x15,
 };
 
-// Converts a GetInfo response key to a cbor::Value.
-cbor::Value CborValue(InfoMember response);
-
 // Checks if the key is used in this enum.
 bool InfoMemberContains(int64_t key);
 
@@ -235,9 +235,6 @@ enum class ClientPinResponse : uint8_t {
   kPowerCycleState = 0x04,
   kUvRetries = 0x05,
 };
-
-// Converts a ClientPin response key to a cbor::Value.
-cbor::Value CborValue(ClientPinResponse response);
 
 // Checks if the key is used in this enum.
 bool ClientPinResponseContains(int64_t key);
@@ -264,9 +261,6 @@ enum class CredentialManagementResponse : uint8_t {
   kCredProtect = 0x0A,
   kLargeBlobKey = 0x0B,
 };
-
-// Converts a CredentialManagement response key to a cbor::Value.
-cbor::Value CborValue(CredentialManagementResponse response);
 
 // Checks if the key is used in this enum.
 bool CredentialManagementResponseContains(int64_t key);
@@ -311,9 +305,6 @@ enum class BioEnrollmentResponse : uint8_t {
   kMaxTemplateFriendlyName = 0x08,
 };
 
-// Converts a BioEnrollment response key to a cbor::Value.
-cbor::Value CborValue(BioEnrollmentResponse response);
-
 // Checks if the key is used in this enum.
 bool BioEnrollmentResponseContains(int64_t key);
 
@@ -349,9 +340,6 @@ enum class LargeBlobsParameters : uint8_t {
 enum class LargeBlobsResponse : uint8_t {
   kConfig = 0x01,
 };
-
-// Converts a LargeBlobs response key to a cbor::Value.
-cbor::Value CborValue(LargeBlobsResponse response);
 
 // Checks if the key is used in this enum.
 bool LargeBlobsResponseContains(int64_t key);

--- a/src/crypto_utility.cc
+++ b/src/crypto_utility.cc
@@ -93,8 +93,7 @@ void WritePublicKeyToCoseMap(const EC_GROUP* ec_group,
   // Beware here: Despite the algorithm's name, this is not supposed to do
   // SHA256 at the end. The algorithm identifier is only there for backwards
   // compatibility.
-  (*cose_public_key_out)[cbor::Value(3)] =
-      cbor::Value(static_cast<int>(Algorithm::kEcdhEsHkdf256));
+  (*cose_public_key_out)[cbor::Value(3)] = CborValue(Algorithm::kEcdhEsHkdf256);
   (*cose_public_key_out)[cbor::Value(-1)] = cbor::Value(kCurveParameter);
   (*cose_public_key_out)[cbor::Value(-2)] = cbor::Value(platform_public_key_x);
   (*cose_public_key_out)[cbor::Value(-3)] = cbor::Value(platform_public_key_y);
@@ -127,8 +126,7 @@ cbor::Value::MapValue GenerateExampleEcdhCoseKey() {
   cbor::Value::MapValue example_cose_key;
   example_cose_key[cbor::Value(1)] = cbor::Value(kEcdhKeyType);
   // The spec asks for -25, even though it is not the algorithm in use.
-  example_cose_key[cbor::Value(3)] =
-      cbor::Value(static_cast<int>(Algorithm::kEcdhEsHkdf256));
+  example_cose_key[cbor::Value(3)] = CborValue(Algorithm::kEcdhEsHkdf256);
   example_cose_key[cbor::Value(-1)] = cbor::Value(kCurveParameter);
   example_cose_key[cbor::Value(-2)] = cbor::Value(cbor::Value::BinaryValue(
       {0xb2, 0x07, 0x17, 0xfb, 0xc7, 0xc8, 0x25, 0x17, 0xf5, 0x11, 0x02,

--- a/src/crypto_utility.cc
+++ b/src/crypto_utility.cc
@@ -93,7 +93,7 @@ void WritePublicKeyToCoseMap(const EC_GROUP* ec_group,
   // Beware here: Despite the algorithm's name, this is not supposed to do
   // SHA256 at the end. The algorithm identifier is only there for backwards
   // compatibility.
-  (*cose_public_key_out)[cbor::Value(3)] = CborValue(Algorithm::kEcdhEsHkdf256);
+  (*cose_public_key_out)[cbor::Value(3)] = CborInt(Algorithm::kEcdhEsHkdf256);
   (*cose_public_key_out)[cbor::Value(-1)] = cbor::Value(kCurveParameter);
   (*cose_public_key_out)[cbor::Value(-2)] = cbor::Value(platform_public_key_x);
   (*cose_public_key_out)[cbor::Value(-3)] = cbor::Value(platform_public_key_y);
@@ -126,7 +126,7 @@ cbor::Value::MapValue GenerateExampleEcdhCoseKey() {
   cbor::Value::MapValue example_cose_key;
   example_cose_key[cbor::Value(1)] = cbor::Value(kEcdhKeyType);
   // The spec asks for -25, even though it is not the algorithm in use.
-  example_cose_key[cbor::Value(3)] = CborValue(Algorithm::kEcdhEsHkdf256);
+  example_cose_key[cbor::Value(3)] = CborInt(Algorithm::kEcdhEsHkdf256);
   example_cose_key[cbor::Value(-1)] = cbor::Value(kCurveParameter);
   example_cose_key[cbor::Value(-2)] = cbor::Value(cbor::Value::BinaryValue(
       {0xb2, 0x07, 0x17, 0xfb, 0xc7, 0xc8, 0x25, 0x17, 0xf5, 0x11, 0x02,

--- a/src/device_tracker.cc
+++ b/src/device_tracker.cc
@@ -80,7 +80,7 @@ void DeviceTracker::Initialize(const cbor::Value::MapValue& info_map) {
   }
   is_initialized_ = true;
 
-  auto map_iter = info_map.find(CborValue(InfoMember::kVersions));
+  auto map_iter = info_map.find(CborInt(InfoMember::kVersions));
   CHECK(map_iter != info_map.end())
       << "no versions in GetInfo response - TEST SUITE BUG";
   const cbor::Value::ArrayValue& versions = map_iter->second.GetArray();
@@ -90,7 +90,7 @@ void DeviceTracker::Initialize(const cbor::Value::MapValue& info_map) {
     }
   }
 
-  map_iter = info_map.find(CborValue(InfoMember::kExtensions));
+  map_iter = info_map.find(CborInt(InfoMember::kExtensions));
   if (map_iter != info_map.end()) {
     const cbor::Value::ArrayValue& extensions = map_iter->second.GetArray();
     for (const auto& extensions_iter : extensions) {
@@ -100,7 +100,7 @@ void DeviceTracker::Initialize(const cbor::Value::MapValue& info_map) {
     }
   }
 
-  map_iter = info_map.find(CborValue(InfoMember::kOptions));
+  map_iter = info_map.find(CborInt(InfoMember::kOptions));
   cbor::Value::MapValue empty_options;
   const cbor::Value::MapValue& options =
       map_iter != info_map.end() ? map_iter->second.GetMap() : empty_options;
@@ -124,7 +124,7 @@ void DeviceTracker::Initialize(const cbor::Value::MapValue& info_map) {
     }
   }
 
-  map_iter = info_map.find(CborValue(InfoMember::kMinPinLength));
+  map_iter = info_map.find(CborInt(InfoMember::kMinPinLength));
   if (map_iter != info_map.end()) {
     min_pin_length_ = map_iter->second.GetUnsigned();
   }

--- a/src/device_tracker_test.cc
+++ b/src/device_tracker_test.cc
@@ -34,9 +34,9 @@ TEST(DeviceTracker, TestInitialize) {
   options[cbor::Value("clientPin")] = cbor::Value(false);
   options[cbor::Value("bioEnroll")] = cbor::Value(true);
   cbor::Value::MapValue info;
-  info[CborValue(InfoMember::kVersions)] = cbor::Value(versions);
-  info[CborValue(InfoMember::kExtensions)] = cbor::Value(extensions);
-  info[CborValue(InfoMember::kOptions)] = cbor::Value(options);
+  info[CborInt(InfoMember::kVersions)] = cbor::Value(versions);
+  info[CborInt(InfoMember::kExtensions)] = cbor::Value(extensions);
+  info[CborInt(InfoMember::kOptions)] = cbor::Value(options);
 
   device_tracker.Initialize(info);
   EXPECT_TRUE(device_tracker.HasVersion("VERSION"));
@@ -53,7 +53,7 @@ TEST(DeviceTracker, TestInitializeDefault) {
   DeviceTracker device_tracker = DeviceTracker();
   cbor::Value::ArrayValue versions;
   cbor::Value::MapValue info;
-  info[CborValue(InfoMember::kVersions)] = cbor::Value(versions);
+  info[CborInt(InfoMember::kVersions)] = cbor::Value(versions);
 
   device_tracker.Initialize(info);
   EXPECT_TRUE(device_tracker.HasOption("up"));
@@ -65,8 +65,8 @@ TEST(DeviceTracker, TestGetMinPinLength) {
 
   cbor::Value::ArrayValue versions;
   cbor::Value::MapValue info;
-  info[CborValue(InfoMember::kVersions)] = cbor::Value(versions);
-  info[CborValue(InfoMember::kMinPinLength)] = cbor::Value(6);
+  info[CborInt(InfoMember::kVersions)] = cbor::Value(versions);
+  info[CborInt(InfoMember::kMinPinLength)] = cbor::Value(6);
   device_tracker.Initialize(info);
   EXPECT_EQ(device_tracker.GetMinPinLength(), 6);
 }
@@ -106,9 +106,9 @@ TEST(DeviceTracker, TestGenerateResultsJson) {
   cbor::Value::MapValue options;
   options[cbor::Value("up")] = cbor::Value(true);
   cbor::Value::MapValue info;
-  info[CborValue(InfoMember::kVersions)] = cbor::Value(versions);
-  info[CborValue(InfoMember::kExtensions)] = cbor::Value(extensions);
-  info[CborValue(InfoMember::kOptions)] = cbor::Value(options);
+  info[CborInt(InfoMember::kVersions)] = cbor::Value(versions);
+  info[CborInt(InfoMember::kExtensions)] = cbor::Value(extensions);
+  info[CborInt(InfoMember::kOptions)] = cbor::Value(options);
 
   device_tracker.Initialize(info);
   device_tracker.SetDeviceIdentifiers({.manufacturer = "M",

--- a/src/fido2_commands.cc
+++ b/src/fido2_commands.cc
@@ -102,7 +102,7 @@ size_t PubKeyDuplicateCheck(KeyChecker* key_checker,
 std::string ExtractRpIdFromMakeCredentialRequest(const cbor::Value& request) {
   CHECK(request.is_map()) << "request is not a map - TEST SUITE BUG";
   const auto& request_map = request.GetMap();
-  auto req_iter = request_map.find(CborValue(MakeCredentialParameters::kRp));
+  auto req_iter = request_map.find(CborInt(MakeCredentialParameters::kRp));
   CHECK(req_iter != request_map.end()) << "RP not in request - TEST SUITE BUG";
   CHECK(req_iter->second.is_map()) << "RP is not a map - TEST SUITE BUG";
   const auto& inner_map = req_iter->second.GetMap();
@@ -117,7 +117,7 @@ std::string ExtractRpIdFromMakeCredentialRequest(const cbor::Value& request) {
 std::string ExtractRpIdFromGetAssertionRequest(const cbor::Value& request) {
   CHECK(request.is_map()) << "request is not a map - TEST SUITE BUG";
   const auto& request_map = request.GetMap();
-  auto req_iter = request_map.find(CborValue(GetAssertionParameters::kRpId));
+  auto req_iter = request_map.find(CborInt(GetAssertionParameters::kRpId));
   CHECK(req_iter != request_map.end())
       << "RP ID not in request - TEST SUITE BUG";
   CHECK(req_iter->second.is_string())
@@ -128,7 +128,7 @@ std::string ExtractRpIdFromGetAssertionRequest(const cbor::Value& request) {
 PinSubCommand ExtractPinSubCommand(const cbor::Value& request) {
   CHECK(request.is_map()) << "request is not a map - TEST SUITE BUG";
   const auto& request_map = request.GetMap();
-  auto req_iter = request_map.find(CborValue(ClientPinParameters::kSubCommand));
+  auto req_iter = request_map.find(CborInt(ClientPinParameters::kSubCommand));
   CHECK(req_iter != request_map.end())
       << "subcommand not in request - TEST SUITE BUG";
   return static_cast<PinSubCommand>(req_iter->second.GetUnsigned());
@@ -138,8 +138,7 @@ cbor::Value::BinaryValue ExtractUniqueCredentialFromAllowList(
     const cbor::Value& request) {
   CHECK(request.is_map()) << "request is not a map - TEST SUITE BUG";
   const auto& request_map = request.GetMap();
-  auto req_iter =
-      request_map.find(CborValue(GetAssertionParameters::kAllowList));
+  auto req_iter = request_map.find(CborInt(GetAssertionParameters::kAllowList));
   CHECK(req_iter != request_map.end())
       << "allow list not in request - TEST SUITE BUG";
   CHECK(req_iter->second.is_array())
@@ -162,7 +161,7 @@ cbor::Value::BinaryValue ExtractUniqueCredentialFromAllowList(
 bool ExtractUpOptionFromGetAssertionRequest(const cbor::Value& request) {
   CHECK(request.is_map()) << "request is not a map - TEST SUITE BUG";
   const auto& request_map = request.GetMap();
-  auto req_iter = request_map.find(CborValue(GetAssertionParameters::kOptions));
+  auto req_iter = request_map.find(CborInt(GetAssertionParameters::kOptions));
   if (req_iter == request_map.end()) {
     return true;
   }
@@ -197,13 +196,13 @@ absl::variant<cbor::Value, Status> MakeCredentialPositiveTest(
   CHECK(decoded_response->is_map()) << "CBOR response is not a map";
   const auto& decoded_map = decoded_response->GetMap();
 
-  auto map_iter = decoded_map.find(CborValue(MakeCredentialResponse::kFmt));
+  auto map_iter = decoded_map.find(CborInt(MakeCredentialResponse::kFmt));
   CHECK(map_iter != decoded_map.end())
       << "no fmt (key 1) in MakeCredential response";
   CHECK(map_iter->second.is_string()) << "fmt is not a string";
   std::string fmt = map_iter->second.GetString();
 
-  map_iter = decoded_map.find(CborValue(MakeCredentialResponse::kAuthData));
+  map_iter = decoded_map.find(CborInt(MakeCredentialResponse::kAuthData));
   CHECK(map_iter != decoded_map.end())
       << "no authData (key 2) in MakeCredential response";
   CHECK(map_iter->second.is_bytestring())
@@ -258,7 +257,7 @@ absl::variant<cbor::Value, Status> MakeCredentialPositiveTest(
   ByteVector extension_data(cose_key.begin() + cose_key_size, cose_key.end());
   CheckExtensions(extension_data);
 
-  map_iter = decoded_map.find(CborValue(MakeCredentialResponse::kAttStmt));
+  map_iter = decoded_map.find(CborInt(MakeCredentialResponse::kAttStmt));
   CHECK(map_iter != decoded_map.end())
       << "no attStmt (key 3) in MakeCredential response";
 
@@ -325,8 +324,7 @@ absl::variant<cbor::Value, Status> GetAssertionPositiveTest(
   CHECK(decoded_response->is_map()) << "CBOR response is not a map";
   const auto& decoded_map = decoded_response->GetMap();
 
-  auto map_iter =
-      decoded_map.find(CborValue(GetAssertionResponse::kCredential));
+  auto map_iter = decoded_map.find(CborInt(GetAssertionResponse::kCredential));
   cbor::Value::BinaryValue credential_id;
   if (map_iter == decoded_map.end()) {
     // Allow list length 1 can be enforced here because only then is not
@@ -344,7 +342,7 @@ absl::variant<cbor::Value, Status> GetAssertionPositiveTest(
     credential_id = inner_iter->second.GetBytestring();
   }
 
-  map_iter = decoded_map.find(CborValue(GetAssertionResponse::kAuthData));
+  map_iter = decoded_map.find(CborInt(GetAssertionResponse::kAuthData));
   CHECK(map_iter != decoded_map.end())
       << "no authData (key 2) in GetAssertion response";
   CHECK(map_iter->second.is_bytestring())
@@ -382,7 +380,7 @@ absl::variant<cbor::Value, Status> GetAssertionPositiveTest(
   ByteVector extension_data(auth_data.begin() + 37, auth_data.end());
   CheckExtensions(extension_data);
 
-  map_iter = decoded_map.find(CborValue(GetAssertionResponse::kSignature));
+  map_iter = decoded_map.find(CborInt(GetAssertionResponse::kSignature));
   CHECK(map_iter != decoded_map.end())
       << "no signature (key 3) in GetAssertion response";
   CHECK(map_iter->second.is_bytestring())
@@ -395,7 +393,7 @@ absl::variant<cbor::Value, Status> GetAssertionPositiveTest(
   // What is the intended way to remember the algorithm used? Just somehow store
   // it along with the PublicKeyCredentialSource? What about non-resident keys?
 
-  map_iter = decoded_map.find(CborValue(GetAssertionResponse::kUser));
+  map_iter = decoded_map.find(CborInt(GetAssertionResponse::kUser));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_map()) << "user entry is not a map";
     const auto& user = map_iter->second.GetMap();
@@ -426,7 +424,7 @@ absl::variant<cbor::Value, Status> GetAssertionPositiveTest(
   }
 
   map_iter =
-      decoded_map.find(CborValue(GetAssertionResponse::kNumberOfCredentials));
+      decoded_map.find(CborInt(GetAssertionResponse::kNumberOfCredentials));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_unsigned())
         << "number of credentials entry is not an unsigned";
@@ -470,7 +468,7 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
   CHECK(decoded_response->is_map()) << "CBOR response is not a map";
   const auto& decoded_map = decoded_response->GetMap();
 
-  auto map_iter = decoded_map.find(CborValue(InfoMember::kVersions));
+  auto map_iter = decoded_map.find(CborInt(InfoMember::kVersions));
   CHECK(map_iter != decoded_map.end())
       << "no versions (key 1) included in GetInfo response";
   CHECK(map_iter->second.is_array()) << "versions entry is not an array";
@@ -484,7 +482,7 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
   CHECK(versions_set.find("FIDO_2_0") != versions_set.end())
       << "versions does not contain \"FIDO_2_0\"";
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kExtensions));
+  map_iter = decoded_map.find(CborInt(InfoMember::kExtensions));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_array()) << "extensions entry is not an array";
     absl::flat_hash_set<std::string> extensions_set;
@@ -496,12 +494,12 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
     }
   }
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kAaguid));
+  map_iter = decoded_map.find(CborInt(InfoMember::kAaguid));
   CHECK(map_iter != decoded_map.end())
       << "no AAGUID (key 3) in GetInfo response";
   CHECK(map_iter->second.is_bytestring()) << "aaguid entry is not a bytestring";
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kOptions));
+  map_iter = decoded_map.find(CborInt(InfoMember::kOptions));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_map()) << "options entry is not a map";
     for (const auto& options_iter : map_iter->second.GetMap()) {
@@ -510,13 +508,13 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
     }
   }
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kMaxMsgSize));
+  map_iter = decoded_map.find(CborInt(InfoMember::kMaxMsgSize));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_unsigned())
         << "maxMsgSize entry is not an unsigned";
   }
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kPinUvAuthProtocols));
+  map_iter = decoded_map.find(CborInt(InfoMember::kPinUvAuthProtocols));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_array())
         << "pinUvAuthProtocols entry is not an array";
@@ -526,19 +524,19 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
     }
   }
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kMaxCredentialCountInList));
+  map_iter = decoded_map.find(CborInt(InfoMember::kMaxCredentialCountInList));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_unsigned())
         << "maxCredentialCountInList entry is not an unsigned";
   }
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kMaxCredentialIdLength));
+  map_iter = decoded_map.find(CborInt(InfoMember::kMaxCredentialIdLength));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_unsigned())
         << "maxCredentialIdLength entry is not an unsigned";
   }
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kTransports));
+  map_iter = decoded_map.find(CborInt(InfoMember::kTransports));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_array()) << "transports entry is not an array";
     absl::flat_hash_set<std::string> transports_set;
@@ -550,7 +548,7 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
     }
   }
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kAlgorithms));
+  map_iter = decoded_map.find(CborInt(InfoMember::kAlgorithms));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_array()) << "algorithms entry is not an array";
     absl::flat_hash_set<int> algorithms_set;
@@ -577,7 +575,7 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
   }
 
   map_iter =
-      decoded_map.find(CborValue(InfoMember::kMaxSerializedLargeBlobArray));
+      decoded_map.find(CborInt(InfoMember::kMaxSerializedLargeBlobArray));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_unsigned())
         << "maxSerializedLargeBlobArray entry is not an unsigned";
@@ -585,25 +583,25 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
         << "maxSerializedLargeBlobArray is too small";
   }
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kForcePinChange));
+  map_iter = decoded_map.find(CborInt(InfoMember::kForcePinChange));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_bool()) << "forcePINChangeentry is not a bool";
   }
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kMinPinLength));
+  map_iter = decoded_map.find(CborInt(InfoMember::kMinPinLength));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_unsigned())
         << "minPINLength entry is not an unsigned";
     CHECK_GE(map_iter->second.GetUnsigned(), 4) << "minPINLength is too small";
   }
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kFirmwareVersion));
+  map_iter = decoded_map.find(CborInt(InfoMember::kFirmwareVersion));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_unsigned())
         << "firmwareVersion entry is not an unsigned";
   }
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kMaxCredBlobLength));
+  map_iter = decoded_map.find(CborInt(InfoMember::kMaxCredBlobLength));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_unsigned())
         << "maxCredBlobLength entry is not an unsigned";
@@ -611,40 +609,39 @@ absl::variant<cbor::Value, Status> GetInfoPositiveTest(
         << "maxCredBlobLength is too small";
   }
 
-  map_iter =
-      decoded_map.find(CborValue(InfoMember::kMaxRpIdsForSetMinPinLength));
+  map_iter = decoded_map.find(CborInt(InfoMember::kMaxRpIdsForSetMinPinLength));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_unsigned())
         << "maxRPIDsForSetMinPINLength entry is not an unsigned";
   }
 
   map_iter =
-      decoded_map.find(CborValue(InfoMember::kPreferredPlatformUvAttempts));
+      decoded_map.find(CborInt(InfoMember::kPreferredPlatformUvAttempts));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_unsigned())
         << "preferredPlatformUvAttempts entry is not an unsigned";
   }
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kUvModality));
+  map_iter = decoded_map.find(CborInt(InfoMember::kUvModality));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_unsigned())
         << "uvModality entry is not an unsigned";
   }
 
-  map_iter = decoded_map.find(CborValue(InfoMember::kCertifications));
+  map_iter = decoded_map.find(CborInt(InfoMember::kCertifications));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_map()) << "certifications entry is not a map";
   }
 
-  map_iter = decoded_map.find(
-      CborValue(InfoMember::kRemainingDiscoverableCredentials));
+  map_iter =
+      decoded_map.find(CborInt(InfoMember::kRemainingDiscoverableCredentials));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_unsigned())
         << "remainingDiscoverableCredentials entry is not an unsigned";
   }
 
   map_iter =
-      decoded_map.find(CborValue(InfoMember::kVendorPrototypeConfigCommands));
+      decoded_map.find(CborInt(InfoMember::kVendorPrototypeConfigCommands));
   if (map_iter != decoded_map.end()) {
     CHECK(map_iter->second.is_array())
         << "vendorPrototypeConfigCommands entry is not an array";
@@ -703,15 +700,13 @@ absl::variant<cbor::Value, Status> AuthenticatorClientPinPositiveTest(
   switch (subcommand) {
     case PinSubCommand::kGetPinRetries: {
       allowed_map_keys.insert(ClientPinResponse::kPinRetries);
-      auto map_iter =
-          decoded_map.find(CborValue(ClientPinResponse::kPinRetries));
+      auto map_iter = decoded_map.find(CborInt(ClientPinResponse::kPinRetries));
       CHECK(map_iter != decoded_map.end())
           << "no PIN retries (key 3) included in PIN protocol response";
       CHECK(map_iter->second.is_unsigned())
           << "PIN retries entry is not an unsigned";
       allowed_map_keys.insert(ClientPinResponse::kPowerCycleState);
-      map_iter =
-          decoded_map.find(CborValue(ClientPinResponse::kPowerCycleState));
+      map_iter = decoded_map.find(CborInt(ClientPinResponse::kPowerCycleState));
       if (map_iter != decoded_map.end()) {
         CHECK(map_iter->second.is_bool())
             << "powerCycleState entry is not a boolean";
@@ -721,7 +716,7 @@ absl::variant<cbor::Value, Status> AuthenticatorClientPinPositiveTest(
     case PinSubCommand::kGetKeyAgreement: {
       allowed_map_keys.insert(ClientPinResponse::kKeyAgreement);
       auto map_iter =
-          decoded_map.find(CborValue(ClientPinResponse::kKeyAgreement));
+          decoded_map.find(CborInt(ClientPinResponse::kKeyAgreement));
       CHECK(map_iter != decoded_map.end())
           << "no KeyAgreement (key 1) in PIN protocol response";
       CHECK(map_iter->second.is_map()) << "KeyAgreement entry is not a map";
@@ -738,7 +733,7 @@ absl::variant<cbor::Value, Status> AuthenticatorClientPinPositiveTest(
     case PinSubCommand::kGetPinToken: {
       allowed_map_keys.insert(ClientPinResponse::kPinUvAuthToken);
       auto map_iter =
-          decoded_map.find(CborValue(ClientPinResponse::kPinUvAuthToken));
+          decoded_map.find(CborInt(ClientPinResponse::kPinUvAuthToken));
       CHECK(map_iter != decoded_map.end())
           << "no pinUvAuthToken (key 2) in PIN protocol response";
       CHECK(map_iter->second.is_bytestring())
@@ -748,7 +743,7 @@ absl::variant<cbor::Value, Status> AuthenticatorClientPinPositiveTest(
     case PinSubCommand::kGetPinUvAuthTokenUsingUvWithPermissions: {
       allowed_map_keys.insert(ClientPinResponse::kPinUvAuthToken);
       auto map_iter =
-          decoded_map.find(CborValue(ClientPinResponse::kPinUvAuthToken));
+          decoded_map.find(CborInt(ClientPinResponse::kPinUvAuthToken));
       CHECK(map_iter != decoded_map.end())
           << "no pinUvAuthToken (key 2) in PIN protocol response";
       CHECK(map_iter->second.is_bytestring())
@@ -758,13 +753,13 @@ absl::variant<cbor::Value, Status> AuthenticatorClientPinPositiveTest(
     case PinSubCommand::kGetUvRetries: {
       allowed_map_keys.insert(ClientPinResponse::kPowerCycleState);
       auto map_iter =
-          decoded_map.find(CborValue(ClientPinResponse::kPowerCycleState));
+          decoded_map.find(CborInt(ClientPinResponse::kPowerCycleState));
       if (map_iter != decoded_map.end()) {
         CHECK(map_iter->second.is_bool())
             << "powerCycleState entry is not a boolean";
       }
       allowed_map_keys.insert(ClientPinResponse::kUvRetries);
-      map_iter = decoded_map.find(CborValue(ClientPinResponse::kUvRetries));
+      map_iter = decoded_map.find(CborInt(ClientPinResponse::kUvRetries));
       CHECK(map_iter != decoded_map.end())
           << "no UV retries (key 5) included in PIN protocol response";
       CHECK(map_iter->second.is_unsigned())
@@ -774,7 +769,7 @@ absl::variant<cbor::Value, Status> AuthenticatorClientPinPositiveTest(
     case PinSubCommand::kGetPinUvAuthTokenUsingPinWithPermissions: {
       allowed_map_keys.insert(ClientPinResponse::kPinUvAuthToken);
       auto map_iter =
-          decoded_map.find(CborValue(ClientPinResponse::kPinUvAuthToken));
+          decoded_map.find(CborInt(ClientPinResponse::kPinUvAuthToken));
       CHECK(map_iter != decoded_map.end())
           << "no pinUvAuthToken (key 2) in PIN protocol response";
       CHECK(map_iter->second.is_bytestring())

--- a/src/tests/general.cc
+++ b/src/tests/general.cc
@@ -51,8 +51,7 @@ std::optional<std::string> GetInfoTest::Execute(
   }
 
   const auto& decoded_map = absl::get<cbor::Value>(response).GetMap();
-  auto map_iter = decoded_map.find(
-      cbor::Value(static_cast<uint8_t>(InfoMember::kPinUvAuthProtocols)));
+  auto map_iter = decoded_map.find(CborValue(InfoMember::kPinUvAuthProtocols));
   bool has_pin_protocol_1 = false;
   if (map_iter != decoded_map.end()) {
     for (const auto& pin_protocol : map_iter->second.GetArray()) {

--- a/src/tests/general.cc
+++ b/src/tests/general.cc
@@ -51,7 +51,7 @@ std::optional<std::string> GetInfoTest::Execute(
   }
 
   const auto& decoded_map = absl::get<cbor::Value>(response).GetMap();
-  auto map_iter = decoded_map.find(CborValue(InfoMember::kPinUvAuthProtocols));
+  auto map_iter = decoded_map.find(CborInt(InfoMember::kPinUvAuthProtocols));
   bool has_pin_protocol_1 = false;
   if (map_iter != decoded_map.end()) {
     for (const auto& pin_protocol : map_iter->second.GetArray()) {

--- a/src/tests/get_assertion.cc
+++ b/src/tests/get_assertion.cc
@@ -632,7 +632,7 @@ std::optional<std::string> GetAssertionEmptyUserIdTest::Execute(
 
   cbor::Value assertion_response = std::move(absl::get<cbor::Value>(response));
   const auto& decoded_map = assertion_response.GetMap();
-  auto map_iter = decoded_map.find(CborValue(GetAssertionResponse::kUser));
+  auto map_iter = decoded_map.find(CborInt(GetAssertionResponse::kUser));
   if (map_iter != decoded_map.end()) {
     return "The response includes user with an empty ID. This behaviour has "
            "known interoperability hurdles.";

--- a/src/tests/make_credential.cc
+++ b/src/tests/make_credential.cc
@@ -318,7 +318,7 @@ std::optional<std::string> MakeCredentialCredParamsTest::Execute(
   }
 
   pub_key_cred_params.clear();
-  test_cred_param[cbor::Value("alg")] = CborValue(Algorithm::kEs256Algorithm);
+  test_cred_param[cbor::Value("alg")] = CborInt(Algorithm::kEs256Algorithm);
   test_cred_param[cbor::Value("type")] = cbor::Value("non-existing type");
   pub_key_cred_params.push_back(cbor::Value(test_cred_param));
   cose_algorithm_builder.SetMapEntry(
@@ -332,7 +332,7 @@ std::optional<std::string> MakeCredentialCredParamsTest::Execute(
   }
 
   pub_key_cred_params.clear();
-  test_cred_param[cbor::Value("alg")] = CborValue(Algorithm::kEs256Algorithm);
+  test_cred_param[cbor::Value("alg")] = CborInt(Algorithm::kEs256Algorithm);
   test_cred_param[cbor::Value("type")] = cbor::Value("public-key");
   pub_key_cred_params.push_back(cbor::Value(test_cred_param));
   test_cred_param[cbor::Value("alg")] = cbor::Value(-1);

--- a/src/tests/make_credential.cc
+++ b/src/tests/make_credential.cc
@@ -318,8 +318,7 @@ std::optional<std::string> MakeCredentialCredParamsTest::Execute(
   }
 
   pub_key_cred_params.clear();
-  test_cred_param[cbor::Value("alg")] =
-      cbor::Value(static_cast<int>(Algorithm::kEs256Algorithm));
+  test_cred_param[cbor::Value("alg")] = CborValue(Algorithm::kEs256Algorithm);
   test_cred_param[cbor::Value("type")] = cbor::Value("non-existing type");
   pub_key_cred_params.push_back(cbor::Value(test_cred_param));
   cose_algorithm_builder.SetMapEntry(
@@ -333,8 +332,7 @@ std::optional<std::string> MakeCredentialCredParamsTest::Execute(
   }
 
   pub_key_cred_params.clear();
-  test_cred_param[cbor::Value("alg")] =
-      cbor::Value(static_cast<int>(Algorithm::kEs256Algorithm));
+  test_cred_param[cbor::Value("alg")] = CborValue(Algorithm::kEs256Algorithm);
   test_cred_param[cbor::Value("type")] = cbor::Value("public-key");
   pub_key_cred_params.push_back(cbor::Value(test_cred_param));
   test_cred_param[cbor::Value("alg")] = cbor::Value(-1);

--- a/src/tests/test_helpers.cc
+++ b/src/tests/test_helpers.cc
@@ -96,7 +96,7 @@ std::string CborToString(const std::string& name_prefix,
 // Extracts the PIN retries from an authenticator client PIN response.
 int ExtractPinRetries(const cbor::Value& response) {
   const auto& decoded_map = response.GetMap();
-  auto map_iter = decoded_map.find(CborValue(ClientPinResponse::kPinRetries));
+  auto map_iter = decoded_map.find(CborInt(ClientPinResponse::kPinRetries));
   CHECK(map_iter != decoded_map.end())
       << "key 3 for pinRetries is not contained";
   CHECK(map_iter->second.is_integer()) << "pinRetries entry is not an integer";
@@ -120,8 +120,7 @@ cbor::Value::BinaryValue ExtractCredentialId(const cbor::Value& response) {
   CHECK(static_cast<uint8_t>(MakeCredentialResponse::kAuthData) ==
         static_cast<uint8_t>(GetAssertionResponse::kAuthData))
       << "assumption about constants broken - TEST SUITE BUG";
-  auto map_iter =
-      decoded_map.find(CborValue(MakeCredentialResponse::kAuthData));
+  auto map_iter = decoded_map.find(CborInt(MakeCredentialResponse::kAuthData));
   CHECK(map_iter != decoded_map.end()) << "key 2 for authData is not contained";
   CHECK(map_iter->second.is_bytestring())
       << "authData entry is not a bytestring";


### PR DESCRIPTION
I cleaned up the `CborValue` implementation to be available for all constants, and now use it throughout the project.

Other cleanups:
- `return Status::kErrTestToolInternal;` from my last minute change in #117 was actually on self-generated data, so `CHECK` is correct
- some fixes and cleanups in the ClientPin response parser (preparing the next PR with `CredentialManagement` that also has subcommands)