### PR TITLE
Allow tests to be specified by command line flag

### DIFF
--- a/src/corpus_test_main.cc
+++ b/src/corpus_test_main.cc
@@ -106,7 +106,8 @@ int main(int argc, char** argv) {
 
   const std::vector<std::unique_ptr<fido2_tests::BaseTest>>& tests =
       fido2_tests::runners::GetCorpusTests(monitor.get(), corpus_dir);
-  fido2_tests::runners::RunTests(device.get(), &tracker, &command_state, tests);
+  fido2_tests::runners::RunTests(device.get(), &tracker, &command_state, tests,
+                                 {});
 
   std::cout << "\nRESULTS" << std::endl;
   tracker.ReportFindings();

--- a/src/fido2_conformance_main.cc
+++ b/src/fido2_conformance_main.cc
@@ -77,7 +77,10 @@ int main(int argc, char** argv) {
   tracker.AssertCondition(tracker.HasCborCapability(),
                           "CBOR support expected.");
 
-  std::set<std::string> test_ids = absl::StrSplit(FLAGS_test_ids, ',');
+  std::set<std::string> test_ids;
+  if (!FLAGS_test_ids.empty()) {
+    test_ids = absl::StrSplit(FLAGS_test_ids, ',');
+  }
   // Setup and run all tests, while tracking their results.
   const std::vector<std::unique_ptr<fido2_tests::BaseTest>>& tests =
       fido2_tests::runners::GetTests();

--- a/src/fido2_conformance_main.cc
+++ b/src/fido2_conformance_main.cc
@@ -14,6 +14,7 @@
 
 #include <iostream>
 
+#include "absl/strings/str_split.h"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
 #include "src/command_state.h"
@@ -29,6 +30,9 @@ DEFINE_string(
     "The path to the device on your operating system, usually /dev/hidraw*.");
 
 DEFINE_bool(verbose, false, "Printing debug logs, i.e. transmitted packets.");
+
+DEFINE_string(test_ids, "",
+              "Comma-separated list of test IDs to run. Empty runs all tests.");
 
 // Calling this function first connects to the device and then executes all test
 // series listed.
@@ -73,10 +77,12 @@ int main(int argc, char** argv) {
   tracker.AssertCondition(tracker.HasCborCapability(),
                           "CBOR support expected.");
 
+  std::set<std::string> test_ids = absl::StrSplit(FLAGS_test_ids, ',');
   // Setup and run all tests, while tracking their results.
   const std::vector<std::unique_ptr<fido2_tests::BaseTest>>& tests =
       fido2_tests::runners::GetTests();
-  fido2_tests::runners::RunTests(device.get(), &tracker, &command_state, tests);
+  fido2_tests::runners::RunTests(device.get(), &tracker, &command_state, tests,
+                                 test_ids);
   // Reset the device to a clean state.
   command_state.Reset();
 

--- a/src/tests/test_series.cc
+++ b/src/tests/test_series.cc
@@ -149,8 +149,13 @@ const std::vector<std::unique_ptr<BaseTest>>& GetCorpusTests(
 
 void RunTests(DeviceInterface* device, DeviceTracker* device_tracker,
               CommandState* command_state,
-              const std::vector<std::unique_ptr<BaseTest>>& tests) {
+              const std::vector<std::unique_ptr<BaseTest>>& tests,
+              const std::set<std::string>& test_ids) {
   for (const auto& test : tests) {
+    if (!test_ids.empty() && test_ids.find(test->GetId()) == test_ids.end()) {
+      // skipping
+      continue;
+    }
     if (test->HasTag(Tag::kClientPin) &&
         !device_tracker->HasOption("clientPin")) {
       continue;

--- a/src/tests/test_series.cc
+++ b/src/tests/test_series.cc
@@ -153,7 +153,6 @@ void RunTests(DeviceInterface* device, DeviceTracker* device_tracker,
               const std::set<std::string>& test_ids) {
   for (const auto& test : tests) {
     if (!test_ids.empty() && test_ids.find(test->GetId()) == test_ids.end()) {
-      // skipping
       continue;
     }
     if (test->HasTag(Tag::kClientPin) &&

--- a/src/tests/test_series.h
+++ b/src/tests/test_series.h
@@ -37,7 +37,8 @@ const std::vector<std::unique_ptr<BaseTest>>& GetCorpusTests(
 // given authenticator by comparing device information and tags.
 void RunTests(DeviceInterface* device, DeviceTracker* device_tracker,
               CommandState* command_state,
-              const std::vector<std::unique_ptr<BaseTest>>& tests);
+              const std::vector<std::unique_ptr<BaseTest>>& tests,
+              const std::set<std::string>& test_ids);
 
 }  // namespace runners
 }  // namespace fido2_tests


### PR DESCRIPTION
Addresses one idea in #125 .

Test names should be separated by commas.

Example use: 
```bazel run //:fido2_conformance -- --token_path=/dev/hidraw0 --test_ids=make_credential_physical_presence,make_credential_option_uv_false```
