### PR TITLE
Run bazel tests on mac 12

### DIFF
--- a/.github/workflows/bazel_test_mac.yml
+++ b/.github/workflows/bazel_test_mac.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   bazel_test:
     name: bazel test all (MacOS)
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Currently configured version (10.15)  is deprecated.

Seen in :
https://github.com/google/CTAP2-test-tool/actions/runs/2781418130
```The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead. For more details see https://github.com/actions/virtual-environments/issues/5583```

More details:

https://github.com/actions/virtual-environments/issues/5583